### PR TITLE
Create separate 'about' screen for device info etc

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="1.8" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,13 +46,15 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     implementation 'com.google.dagger:dagger:2.26'
     kapt 'com.google.dagger:dagger-compiler:2.26'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation "androidx.navigation:navigation-fragment-ktx:2.2.1"
+    implementation "androidx.navigation:navigation-ui-ktx:2.2.1"
 
     kaptTest 'com.google.dagger:dagger-compiler:2.26'
     testImplementation 'junit:junit:4.12'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,14 @@ dependencies {
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    debugImplementation 'androidx.fragment:fragment-testing:1.2.1'
+    testImplementation 'androidx.fragment:fragment-testing:1.2.1'
+    // Must build with androidx.fragment:fragment-testing so that we can run release flavor unit
+    // tests on the CI. But this should be changed from implementation to testImplementation when
+    // its possible to do so.
+    // See https://developer.android.com/training/basics/fragments/testing#configure
+    implementation('androidx.fragment:fragment-testing:1.2.1', {
+        exclude group: 'androidx.test'
+    })
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'io.mockk:mockk:1.9'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
     debugImplementation 'androidx.fragment:fragment-testing:1.2.1'
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'io.mockk:mockk:1.9'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,9 @@ android {
             version "3.10.2"
         }
     }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     testOptions {
         unitTests {
             includeAndroidResources = true
@@ -57,6 +60,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    debugImplementation 'androidx.fragment:fragment-testing:1.2.1'
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'io.mockk:mockk:1.9'
 

--- a/app/src/main/cpp/AudioEngine.cpp
+++ b/app/src/main/cpp/AudioEngine.cpp
@@ -42,6 +42,10 @@ void AudioEngine::start() {
     stream_->requestStart();
 }
 
+void AudioEngine::stop() {
+    stream_->close();
+}
+
 oboe::DataCallbackResult
 AudioEngine::onAudioReady(oboe::AudioStream *audioStream, void *audioData, int32_t numFrames) {
     // We requested AudioFormat::Float so we assume we got it.
@@ -62,3 +66,4 @@ void AudioEngine::playNote(int32_t pitch) {
 void AudioEngine::stopNote() {
     oscillator_->setWaveOn(false);
 }
+

--- a/app/src/main/cpp/AudioEngine.h
+++ b/app/src/main/cpp/AudioEngine.h
@@ -20,6 +20,8 @@ public:
 
     void start();
 
+    void stop();
+
     void playNote(int32_t);
 
     void stopNote();

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -20,6 +20,11 @@ Java_com_flatmapdev_synth_jni_NativeSynth_start() {
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_flatmapdev_synth_jni_NativeSynth_stop() {
+    audioEngine.stop();
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_flatmapdev_synth_jni_NativeSynth_playNote(
         JNIEnv *env,
         jclass cls,

--- a/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
@@ -1,0 +1,40 @@
+package com.flatmapdev.synth.aboutUi
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import com.flatmapdev.synth.R
+import com.flatmapdev.synth.app.App
+import com.flatmapdev.synth.deviceCore.useCase.GetDeviceFeatures
+import com.flatmapdev.synth.engineCore.adapter.SynthEngineAdapter
+import kotlinx.android.synthetic.main.fragment_about.*
+import javax.inject.Inject
+
+class AboutFragment : Fragment(R.layout.fragment_about) {
+    @Inject
+    lateinit var getDeviceFeatures: GetDeviceFeatures
+
+    @Inject
+    lateinit var synthEngineAdapter: SynthEngineAdapter
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        (context.applicationContext as App).appComponent.inject(this)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        engineVersion.text = getString(
+            R.string.app_engine_version,
+            synthEngineAdapter.getVersion()
+        )
+
+        val deviceFeatures = getDeviceFeatures.execute()
+        lowLatencyStatus.text = getString( R.string.device_features_supports_low_latency, deviceFeatures.isLowLatency.toString() )
+        proLatencyStatus.text = getString(
+            R.string.device_features_supports_pro_latency,
+            deviceFeatures.isProLatency.toString()
+        )
+    }
+}

--- a/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
@@ -3,7 +3,9 @@ package com.flatmapdev.synth.aboutUi
 import android.content.Context
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.transition.Fade
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.deviceCore.useCase.GetDeviceFeatures
@@ -17,6 +19,11 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
 
     @Inject
     lateinit var synthEngineAdapter: SynthEngineAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enterTransition =  Fade(Fade.MODE_IN)
+    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)

--- a/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
@@ -3,45 +3,49 @@ package com.flatmapdev.synth.aboutUi
 import android.content.Context
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import androidx.transition.Fade
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
-import com.flatmapdev.synth.deviceCore.useCase.GetDeviceFeatures
-import com.flatmapdev.synth.engineCore.adapter.SynthEngineAdapter
 import kotlinx.android.synthetic.main.fragment_about.*
 import javax.inject.Inject
 
 class AboutFragment : Fragment(R.layout.fragment_about) {
     @Inject
-    lateinit var getDeviceFeatures: GetDeviceFeatures
-
-    @Inject
-    lateinit var synthEngineAdapter: SynthEngineAdapter
+    lateinit var viewModelFactory: AboutViewModel.Factory
+    private lateinit var viewModel: AboutViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enterTransition =  Fade(Fade.MODE_IN)
+        enterTransition = Fade(Fade.MODE_IN)
     }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
         (context.applicationContext as App).appComponent.inject(this)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(AboutViewModel::class.java)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        engineVersion.text = getString(
-            R.string.app_engine_version,
-            synthEngineAdapter.getVersion()
-        )
 
-        val deviceFeatures = getDeviceFeatures.execute()
-        lowLatencyStatus.text = getString( R.string.device_features_supports_low_latency, deviceFeatures.isLowLatency.toString() )
-        proLatencyStatus.text = getString(
-            R.string.device_features_supports_pro_latency,
-            deviceFeatures.isProLatency.toString()
-        )
+        viewModel.engineVersion.observe(viewLifecycleOwner, Observer { value ->
+            engineVersion.text = getString(
+                R.string.app_engine_version, value
+            )
+        })
+
+        viewModel.deviceFeatures.observe(viewLifecycleOwner, Observer { deviceFeatures ->
+            lowLatencyStatus.text = getString(
+                R.string.device_features_supports_low_latency,
+                deviceFeatures.isLowLatency.toString()
+            )
+            proLatencyStatus.text = getString(
+                R.string.device_features_supports_pro_latency,
+                deviceFeatures.isProLatency.toString()
+            )
+        })
     }
 }

--- a/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutViewModel.kt
+++ b/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutViewModel.kt
@@ -1,0 +1,46 @@
+package com.flatmapdev.synth.aboutUi
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.flatmapdev.synth.deviceCore.model.DeviceFeatures
+import com.flatmapdev.synth.deviceCore.useCase.GetDeviceFeatures
+import com.flatmapdev.synth.engineCore.adapter.SynthEngineAdapter
+import dagger.Reusable
+import javax.inject.Inject
+
+class AboutViewModel(
+    getDeviceFeatures: GetDeviceFeatures,
+    synthEngineAdapter: SynthEngineAdapter
+) : ViewModel() {
+
+    private val _deviceFeatures = MutableLiveData<DeviceFeatures>()
+    val deviceFeatures: LiveData<DeviceFeatures> = _deviceFeatures
+
+    private val _engineVersion = MutableLiveData<String>()
+    val engineVersion: LiveData<String> = _engineVersion
+
+    init {
+        _deviceFeatures.value = getDeviceFeatures.execute()
+        _engineVersion.value = synthEngineAdapter.getVersion()
+    }
+
+    @Reusable
+    class Factory @Inject constructor(
+        private val getDeviceFeatures: GetDeviceFeatures,
+        private val synthEngineAdapter: SynthEngineAdapter
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+            return if (modelClass.isAssignableFrom(AboutViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                AboutViewModel(
+                    getDeviceFeatures,
+                    synthEngineAdapter
+                ) as T
+            } else {
+                throw IllegalArgumentException("ViewModel Not Found")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/flatmapdev/synth/app/di/AppComponent.kt
+++ b/app/src/main/java/com/flatmapdev/synth/app/di/AppComponent.kt
@@ -1,9 +1,11 @@
 package com.flatmapdev.synth.app.di
 
 import android.content.Context
+import com.flatmapdev.synth.aboutUi.AboutFragment
 import com.flatmapdev.synth.deviceData.DeviceDataModule
 import com.flatmapdev.synth.engineData.EngineDataModule
 import com.flatmapdev.synth.mainUi.MainActivity
+import com.flatmapdev.synth.mainUi.MainFragment
 import com.flatmapdev.synth.shared.scopes.AppScope
 import dagger.BindsInstance
 import dagger.Component
@@ -16,6 +18,8 @@ import dagger.Component
 )
 @AppScope
 interface AppComponent {
+    fun inject(aboutFragment: AboutFragment)
+    fun inject(mainFragment: MainFragment)
     fun inject(activity: MainActivity)
 
     @Component.Factory

--- a/app/src/main/java/com/flatmapdev/synth/engineCore/adapter/SynthEngineAdapter.kt
+++ b/app/src/main/java/com/flatmapdev/synth/engineCore/adapter/SynthEngineAdapter.kt
@@ -5,6 +5,7 @@ import com.flatmapdev.synth.keyboardCore.model.Key
 interface SynthEngineAdapter {
     fun getVersion(): String
     fun start()
+    fun stop()
     fun playNote(key: Key)
     fun stopNote()
 }

--- a/app/src/main/java/com/flatmapdev/synth/engineData/adapter/NativeSynthEngineAdapter.kt
+++ b/app/src/main/java/com/flatmapdev/synth/engineData/adapter/NativeSynthEngineAdapter.kt
@@ -9,13 +9,11 @@ import javax.inject.Inject
 class NativeSynthEngineAdapter @Inject constructor(
     private val nativeSynth: NativeSynth
 ) : SynthEngineAdapter {
-    override fun getVersion(): String {
-        return nativeSynth.getVersion()
-    }
+    override fun getVersion() = nativeSynth.getVersion()
 
-    override fun start() {
-        nativeSynth.start()
-    }
+    override fun start() = nativeSynth.start()
+
+    override fun stop() = nativeSynth.stop()
 
     override fun playNote(key: Key) {
         nativeSynth.playNote(
@@ -23,7 +21,5 @@ class NativeSynthEngineAdapter @Inject constructor(
         )
     }
 
-    override fun stopNote() {
-        nativeSynth.stopNote()
-    }
+    override fun stopNote() = nativeSynth.stopNote()
 }

--- a/app/src/main/java/com/flatmapdev/synth/jni/NativeSynth.kt
+++ b/app/src/main/java/com/flatmapdev/synth/jni/NativeSynth.kt
@@ -7,6 +7,7 @@ import javax.inject.Inject
 class NativeSynth @Inject constructor() {
     external fun getVersion(): String
     external fun start()
+    external fun stop()
     external fun playNote(pitch: Int)
     external fun stopNote()
 

--- a/app/src/main/java/com/flatmapdev/synth/mainUi/MainActivity.kt
+++ b/app/src/main/java/com/flatmapdev/synth/mainUi/MainActivity.kt
@@ -28,6 +28,11 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         synthEngineAdapter.start()
     }
 
+    override fun onDestroy() {
+        synthEngineAdapter.stop()
+        super.onDestroy()
+    }
+
     override fun onSupportNavigateUp(): Boolean {
         return navController.navigateUp() || super.onSupportNavigateUp()
     }

--- a/app/src/main/java/com/flatmapdev/synth/mainUi/MainActivity.kt
+++ b/app/src/main/java/com/flatmapdev/synth/mainUi/MainActivity.kt
@@ -4,67 +4,19 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
-import com.flatmapdev.synth.deviceCore.useCase.GetDeviceFeatures
 import com.flatmapdev.synth.engineCore.adapter.SynthEngineAdapter
-import com.flatmapdev.synth.keyboardCore.model.Key
-import com.flatmapdev.synth.keyboardCore.useCase.GetKeyboard
-import com.flatmapdev.synth.keyboardCore.useCase.PlayKey
-import com.flatmapdev.synth.keyboardCore.useCase.StopKeys
-import kotlinx.android.synthetic.main.activity_main.*
 import javax.inject.Inject
 
 
-class MainActivity : AppCompatActivity() {
-    @Inject
-    lateinit var getDeviceFeatures: GetDeviceFeatures
-
-    @Inject
-    lateinit var getKeyboard: GetKeyboard
-
-    @Inject
-    lateinit var playKey: PlayKey
-
-    @Inject
-    lateinit var stopKeys: StopKeys
-
+class MainActivity : AppCompatActivity(R.layout.activity_main) {
     @Inject
     lateinit var synthEngineAdapter: SynthEngineAdapter
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         (applicationContext as App).appComponent.inject(this)
 
         super.onCreate(savedInstanceState)
 
-        setContentView(R.layout.activity_main)
-
-        engineVersion.text = getString(
-            R.string.app_engine_version,
-            synthEngineAdapter.getVersion()
-        )
-
-        val deviceFeatures = getDeviceFeatures.execute()
-        lowLatencyStatus.text = getString(
-            R.string.device_features_supports_low_latency,
-            deviceFeatures.isLowLatency.toString()
-        )
-        proLatencyStatus.text = getString(
-            R.string.device_features_supports_pro_latency,
-            deviceFeatures.isProLatency.toString()
-        )
         synthEngineAdapter.start()
-
-        val keys = getKeyboard.execute()
-        setupKeyboard(keys)
-    }
-
-    private fun setupKeyboard(keys: List<Key>) {
-        keyboard.numKeys = keys.size
-        keyboard.keyTouchListener = { keyIndex ->
-            when(keyIndex) {
-                null -> stopKeys.execute()
-                else -> playKey.execute(keys[keyIndex])
-            }
-        }
     }
 }

--- a/app/src/main/java/com/flatmapdev/synth/mainUi/MainActivity.kt
+++ b/app/src/main/java/com/flatmapdev/synth/mainUi/MainActivity.kt
@@ -2,6 +2,9 @@ package com.flatmapdev.synth.mainUi
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.NavController
+import androidx.navigation.findNavController
+import androidx.navigation.ui.NavigationUI
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.engineCore.adapter.SynthEngineAdapter
@@ -12,11 +15,20 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
     @Inject
     lateinit var synthEngineAdapter: SynthEngineAdapter
 
+    private val navController: NavController
+        get() = findNavController(R.id.navHostFragmentContainer)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         (applicationContext as App).appComponent.inject(this)
 
         super.onCreate(savedInstanceState)
 
+        NavigationUI.setupActionBarWithNavController(this, navController)
+
         synthEngineAdapter.start()
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        return navController.navigateUp() || super.onSupportNavigateUp()
     }
 }

--- a/app/src/main/java/com/flatmapdev/synth/mainUi/MainFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/mainUi/MainFragment.kt
@@ -69,5 +69,4 @@ class MainFragment : Fragment(R.layout.fragment_main) {
     private fun navigateToAbout() {
         findNavController().navigate(R.id.aboutFragment)
     }
-
 }

--- a/app/src/main/java/com/flatmapdev/synth/mainUi/MainFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/mainUi/MainFragment.kt
@@ -2,8 +2,13 @@ package com.flatmapdev.synth.mainUi
 
 import android.content.Context
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.transition.Fade
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.keyboardCore.useCase.GetKeyboard
@@ -27,6 +32,13 @@ class MainFragment : Fragment(R.layout.fragment_main) {
         (context.applicationContext as App).appComponent.inject(this)
     }
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+
+        exitTransition =  Fade(Fade.MODE_OUT)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val keys = getKeyboard.execute()
@@ -38,4 +50,24 @@ class MainFragment : Fragment(R.layout.fragment_main) {
             }
         }
     }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_main, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.about -> {
+                navigateToAbout()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun navigateToAbout() {
+        findNavController().navigate(R.id.aboutFragment)
+    }
+
 }

--- a/app/src/main/java/com/flatmapdev/synth/mainUi/MainFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/mainUi/MainFragment.kt
@@ -1,0 +1,41 @@
+package com.flatmapdev.synth.mainUi
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import com.flatmapdev.synth.R
+import com.flatmapdev.synth.app.App
+import com.flatmapdev.synth.keyboardCore.useCase.GetKeyboard
+import com.flatmapdev.synth.keyboardCore.useCase.PlayKey
+import com.flatmapdev.synth.keyboardCore.useCase.StopKeys
+import kotlinx.android.synthetic.main.fragment_main.*
+import javax.inject.Inject
+
+class MainFragment : Fragment(R.layout.fragment_main) {
+    @Inject
+    lateinit var getKeyboard: GetKeyboard
+
+    @Inject
+    lateinit var playKey: PlayKey
+
+    @Inject
+    lateinit var stopKeys: StopKeys
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        (context.applicationContext as App).appComponent.inject(this)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val keys = getKeyboard.execute()
+        keyboard.numKeys = keys.size
+        keyboard.keyTouchListener = { keyIndex ->
+            when (keyIndex) {
+                null -> stopKeys.execute()
+                else -> playKey.execute(keys[keyIndex])
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/flatmapdev/synth/mainUi/MainViewModel.kt
+++ b/app/src/main/java/com/flatmapdev/synth/mainUi/MainViewModel.kt
@@ -1,0 +1,54 @@
+package com.flatmapdev.synth.mainUi
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.flatmapdev.synth.keyboardCore.model.Key
+import com.flatmapdev.synth.keyboardCore.useCase.GetKeyboard
+import com.flatmapdev.synth.keyboardCore.useCase.PlayKey
+import com.flatmapdev.synth.keyboardCore.useCase.StopKeys
+import dagger.Reusable
+import javax.inject.Inject
+
+class MainViewModel(
+    getKeyboard: GetKeyboard,
+    private val playKey: PlayKey,
+    private val stopKeys: StopKeys
+) : ViewModel() {
+
+    private val _keyboard = MutableLiveData<List<Key>>()
+    val keyboard: LiveData<List<Key>> = _keyboard
+
+    init {
+        _keyboard.value = getKeyboard.execute()
+    }
+
+    fun playKey(key: Key) {
+        playKey.execute(key)
+    }
+
+    fun stopKeys() {
+        stopKeys.execute()
+    }
+
+    @Reusable
+    class Factory @Inject constructor(
+        private val getKeyboard: GetKeyboard,
+        private val playKey: PlayKey,
+        private val stopKeys: StopKeys
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+            return if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                MainViewModel(
+                    getKeyboard,
+                    playKey,
+                    stopKeys
+                ) as T
+            } else {
+                throw IllegalArgumentException("ViewModel Not Found")
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,51 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".mainUi.MainActivity">
+    android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/engineVersion"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Debug text" />
+    <fragment
+        android:id="@+id/fragment"
+        android:name="com.flatmapdev.synth.mainUi.MainFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:layout="@layout/fragment_main" />
 
-    <TextView
-        android:id="@+id/lowLatencyStatus"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/engineVersion"
-        tools:text="Supports low latency: true" />
-
-    <TextView
-        android:id="@+id/proLatencyStatus"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.498"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/lowLatencyStatus"
-        tools:text="Supports pro latency: false" />
-
-    <com.flatmapdev.synth.mainUi.KeyboardView
-        android:id="@+id/keyboard"
-        android:layout_width="wrap_content"
-        android:layout_height="0dp"
-        android:layout_marginTop="8dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/proLatencyStatus"
-        app:numKeys="10" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <fragment
-        android:id="@+id/fragment"
-        android:name="com.flatmapdev.synth.mainUi.MainFragment"
+        android:id="@+id/navHostFragmentContainer"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:layout="@layout/fragment_main" />
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".mainUi.MainActivity">
+
+    <TextView
+        android:id="@+id/engineVersion"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Debug text" />
+
+    <TextView
+        android:id="@+id/lowLatencyStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/engineVersion"
+        tools:text="Supports low latency: true" />
+
+    <TextView
+        android:id="@+id/proLatencyStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/lowLatencyStatus"
+        tools:text="Supports pro latency: false" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".mainUi.MainActivity">
+
+    <com.flatmapdev.synth.mainUi.KeyboardView
+        android:id="@+id/keyboard"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:numKeys="10" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/about"
+        android:title="@string/menu_main_about" />
+</menu>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph.xml"
+    app:startDestination="@id/mainFragment">
+
+    <fragment
+        android:id="@+id/mainFragment"
+        android:name="com.flatmapdev.synth.mainUi.MainFragment"
+        android:label="@string/main_title"
+        tools:layout="@layout/fragment_main">
+        <action
+            android:id="@+id/action_mainFragment_to_aboutFragment"
+            app:destination="@id/aboutFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/aboutFragment"
+        android:name="com.flatmapdev.synth.aboutUi.AboutFragment"
+        android:label="@string/about_title"
+        tools:layout="@layout/fragment_about" />
+</navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,7 @@
     <string name="app_engine_version">Engine version: %1$s</string>
     <string name="device_features_supports_low_latency">Supports low latency: %1$s</string>
     <string name="device_features_supports_pro_latency">Supports pro latency: %1$s</string>
+    <string name="menu_main_about">About</string>
+    <string name="about_title">About</string>
+    <string name="main_title">Synth</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_engine_version">Engine version: %1$s</string>
     <string name="device_features_supports_low_latency">Supports low latency: %1$s</string>
     <string name="device_features_supports_pro_latency">Supports pro latency: %1$s</string>
+    <string name="main_title">Synth</string>
     <string name="menu_main_about">About</string>
     <string name="about_title">About</string>
-    <string name="main_title">Synth</string>
 </resources>

--- a/app/src/test/java/com/flatmapdev/synth/aboutUi/AboutFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/aboutUi/AboutFragmentTest.kt
@@ -1,9 +1,10 @@
 package com.flatmapdev.synth.aboutUi
 
 import androidx.fragment.app.testing.launchFragmentInContainer
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.di.DaggerTestAppComponent
@@ -38,8 +39,8 @@ class AboutFragmentTest {
         getApp().appComponent = testComponentBuilder.build()
         launchFragmentInContainer<AboutFragment>()
 
-        Espresso.onView(ViewMatchers.withId(R.id.engineVersion))
-            .check(ViewAssertions.matches(ViewMatchers.withText("Engine version: 1.2.345")))
+        onView(withId(R.id.engineVersion))
+            .check(matches(withText("Engine version: 1.2.345")))
     }
 
     @Test
@@ -56,8 +57,8 @@ class AboutFragmentTest {
             ).build()
         launchFragmentInContainer<AboutFragment>()
 
-        Espresso.onView(ViewMatchers.withId(R.id.lowLatencyStatus))
-            .check(ViewAssertions.matches(ViewMatchers.withText("Supports low latency: true")))
+        onView(withId(R.id.lowLatencyStatus))
+            .check(matches(withText("Supports low latency: true")))
     }
 
     @Test
@@ -74,7 +75,7 @@ class AboutFragmentTest {
             ).build()
         launchFragmentInContainer<AboutFragment>()
 
-        Espresso.onView(ViewMatchers.withId(R.id.proLatencyStatus))
-            .check(ViewAssertions.matches(ViewMatchers.withText("Supports pro latency: true")))
+        onView(withId(R.id.proLatencyStatus))
+            .check(matches(withText("Supports pro latency: true")))
     }
 }

--- a/app/src/test/java/com/flatmapdev/synth/aboutUi/AboutFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/aboutUi/AboutFragmentTest.kt
@@ -1,0 +1,80 @@
+package com.flatmapdev.synth.aboutUi
+
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flatmapdev.synth.R
+import com.flatmapdev.synth.app.di.DaggerTestAppComponent
+import com.flatmapdev.synth.app.getApp
+import com.flatmapdev.synth.doubles.device.FakeDeviceDataModule
+import com.flatmapdev.synth.doubles.device.adapter.StubDeviceFeaturesAdapter
+import com.flatmapdev.synth.doubles.device.model.createDeviceFeatures
+import com.flatmapdev.synth.doubles.engine.FakeEngineDataModule
+import com.flatmapdev.synth.doubles.engine.adapter.FakeSynthEngineAdapter
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AboutFragmentTest {
+    private lateinit var testComponentBuilder: DaggerTestAppComponent.Builder
+
+    @Before
+    fun setUp() {
+        testComponentBuilder = DaggerTestAppComponent.builder()
+    }
+
+    @Test
+    fun `it shows the engine version`() {
+        testComponentBuilder.fakeEngineDataModule(
+            FakeEngineDataModule(
+                FakeSynthEngineAdapter(
+                    version = "1.2.345"
+                )
+            )
+        )
+        getApp().appComponent = testComponentBuilder.build()
+        launchFragmentInContainer<AboutFragment>()
+
+        Espresso.onView(ViewMatchers.withId(R.id.engineVersion))
+            .check(ViewAssertions.matches(ViewMatchers.withText("Engine version: 1.2.345")))
+    }
+
+    @Test
+    fun `it shows the low latency support`() {
+        getApp().appComponent = testComponentBuilder
+            .fakeDeviceDataModule(
+                FakeDeviceDataModule(
+                    deviceFeaturesAdapter = StubDeviceFeaturesAdapter(
+                        deviceFeatures = createDeviceFeatures(
+                            isLowLatency = true
+                        )
+                    )
+                )
+            ).build()
+        launchFragmentInContainer<AboutFragment>()
+
+        Espresso.onView(ViewMatchers.withId(R.id.lowLatencyStatus))
+            .check(ViewAssertions.matches(ViewMatchers.withText("Supports low latency: true")))
+    }
+
+    @Test
+    fun `it shows the pro latency support`() {
+        getApp().appComponent = testComponentBuilder
+            .fakeDeviceDataModule(
+                FakeDeviceDataModule(
+                    deviceFeaturesAdapter = StubDeviceFeaturesAdapter(
+                        deviceFeatures = createDeviceFeatures(
+                            isProLatency = true
+                        )
+                    )
+                )
+            ).build()
+        launchFragmentInContainer<AboutFragment>()
+
+        Espresso.onView(ViewMatchers.withId(R.id.proLatencyStatus))
+            .check(ViewAssertions.matches(ViewMatchers.withText("Supports pro latency: true")))
+    }
+}

--- a/app/src/test/java/com/flatmapdev/synth/aboutUi/AboutViewModelTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/aboutUi/AboutViewModelTest.kt
@@ -1,0 +1,48 @@
+package com.flatmapdev.synth.aboutUi
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.flatmapdev.synth.deviceCore.useCase.GetDeviceFeatures
+import com.flatmapdev.synth.doubles.device.adapter.StubDeviceFeaturesAdapter
+import com.flatmapdev.synth.doubles.device.model.createDeviceFeatures
+import com.flatmapdev.synth.doubles.engine.adapter.FakeSynthEngineAdapter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+
+
+class AboutViewModelTest {
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    @Test
+    fun `it emits the engine version`() {
+        val version = "1.26.4-alpha4"
+        val subject = AboutViewModel(
+            GetDeviceFeatures(StubDeviceFeaturesAdapter()),
+            FakeSynthEngineAdapter(version = version)
+        )
+
+        assertThat(subject.engineVersion.value)
+            .isEqualTo(version)
+    }
+
+    @Test
+    fun `it emits the device features`() {
+        val deviceFeatures = createDeviceFeatures(
+            isLowLatency = true,
+            isProLatency = false
+        )
+        val subject = AboutViewModel(
+            GetDeviceFeatures(
+                StubDeviceFeaturesAdapter(
+                    deviceFeatures = deviceFeatures
+                )
+            ),
+            FakeSynthEngineAdapter()
+        )
+
+        assertThat(subject.deviceFeatures.value)
+            .isEqualTo(deviceFeatures)
+    }
+}

--- a/app/src/test/java/com/flatmapdev/synth/doubles/engine/adapter/FakeSynthEngineAdapter.kt
+++ b/app/src/test/java/com/flatmapdev/synth/doubles/engine/adapter/FakeSynthEngineAdapter.kt
@@ -6,19 +6,13 @@ import com.flatmapdev.synth.keyboardCore.model.Key
 class FakeSynthEngineAdapter(
     private val version: String = "1.0.0"
 ) : SynthEngineAdapter {
-    override fun getVersion(): String {
-        return version
-    }
+    override fun getVersion() = version
 
-    override fun start() {
+    override fun start() {}
 
-    }
+    override fun stop() {}
 
-    override fun playNote(key: Key) {
+    override fun playNote(key: Key) {}
 
-    }
-
-    override fun stopNote() {
-
-    }
+    override fun stopNote() {}
 }

--- a/app/src/test/java/com/flatmapdev/synth/mainUi/MainActivityTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/mainUi/MainActivityTest.kt
@@ -15,6 +15,7 @@ import com.flatmapdev.synth.doubles.engine.FakeEngineDataModule
 import com.flatmapdev.synth.doubles.engine.adapter.FakeSynthEngineAdapter
 import io.mockk.spyk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,5 +45,26 @@ class MainActivityTest {
         onView(isDisplayed())
 
         verify { spySynthEngineAdapter.start() }
+    }
+
+    @Test
+    fun `when it is destroyed, it stops the synth engine`() {
+        val spySynthEngineAdapter = spyk(FakeSynthEngineAdapter())
+        getApp().appComponent = testComponentBuilder
+            .fakeEngineDataModule(
+                FakeEngineDataModule(
+                    synthEngineAdapter = spySynthEngineAdapter
+                )
+            )
+            .build()
+        val scenario = launch<MainActivity>(MainActivity::class.java)
+
+        scenario.recreate()
+
+        verifyOrder {
+            spySynthEngineAdapter.start()
+            spySynthEngineAdapter.stop()
+            spySynthEngineAdapter.start()
+        }
     }
 }

--- a/app/src/test/java/com/flatmapdev/synth/mainUi/MainFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/mainUi/MainFragmentTest.kt
@@ -1,10 +1,11 @@
 package com.flatmapdev.synth.mainUi
 
 import androidx.fragment.app.testing.launchFragmentInContainer
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.di.DaggerTestAppComponent
@@ -31,8 +32,8 @@ class MainFragmentTest {
         getApp().appComponent = testComponentBuilder.build()
         launchFragmentInContainer<MainFragment>()
 
-        Espresso.onView(ViewMatchers.withId(R.id.keyboard))
-            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        onView(withId(R.id.keyboard))
+            .check(matches(isDisplayed()))
     }
 
     @Test
@@ -47,8 +48,8 @@ class MainFragmentTest {
             .build()
         launchFragmentInContainer<MainFragment>()
 
-        Espresso.onView(ViewMatchers.withId(R.id.keyboard))
-            .perform(ViewActions.click())
+        onView(withId(R.id.keyboard))
+            .perform(click())
 
         verify { spySynthEngineAdapter.playNote(any()) }
     }

--- a/app/src/test/java/com/flatmapdev/synth/mainUi/MainFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/mainUi/MainFragmentTest.kt
@@ -1,12 +1,10 @@
 package com.flatmapdev.synth.mainUi
 
-import androidx.test.core.app.ActivityScenario.launch
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.di.DaggerTestAppComponent
@@ -19,9 +17,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
-
 @RunWith(AndroidJUnit4::class)
-class MainActivityTest {
+class MainFragmentTest {
     private lateinit var testComponentBuilder: DaggerTestAppComponent.Builder
 
     @Before
@@ -30,7 +27,16 @@ class MainActivityTest {
     }
 
     @Test
-    fun `it starts the synth engine`() {
+    fun `it shows the keyboard`() {
+        getApp().appComponent = testComponentBuilder.build()
+        launchFragmentInContainer<MainFragment>()
+
+        Espresso.onView(ViewMatchers.withId(R.id.keyboard))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    }
+
+    @Test
+    fun `when a key is tapped, it sends a signal to the synth engine`() {
         val spySynthEngineAdapter = spyk(FakeSynthEngineAdapter())
         getApp().appComponent = testComponentBuilder
             .fakeEngineDataModule(
@@ -39,10 +45,11 @@ class MainActivityTest {
                 )
             )
             .build()
-        launch<MainActivity>(MainActivity::class.java)
+        launchFragmentInContainer<MainFragment>()
 
-        onView(isDisplayed())
+        Espresso.onView(ViewMatchers.withId(R.id.keyboard))
+            .perform(ViewActions.click())
 
-        verify { spySynthEngineAdapter.start() }
+        verify { spySynthEngineAdapter.playNote(any()) }
     }
 }

--- a/app/src/test/java/com/flatmapdev/synth/mainUi/MainViewModelTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/mainUi/MainViewModelTest.kt
@@ -1,0 +1,87 @@
+package com.flatmapdev.synth.mainUi
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.flatmapdev.synth.doubles.engine.adapter.FakeSynthEngineAdapter
+import com.flatmapdev.synth.keyboardCore.model.Key
+import com.flatmapdev.synth.keyboardCore.model.Note
+import com.flatmapdev.synth.keyboardCore.useCase.GetKeyboard
+import com.flatmapdev.synth.keyboardCore.useCase.PlayKey
+import com.flatmapdev.synth.keyboardCore.useCase.StopKeys
+import io.mockk.spyk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+
+
+class MainViewModelTest {
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+
+    private lateinit var fakeSynthEngineAdapter: FakeSynthEngineAdapter
+    private lateinit var spyPlayKey: PlayKey
+    private lateinit var spyStopKeys: StopKeys
+
+    @Before
+    fun setUp() {
+        fakeSynthEngineAdapter = FakeSynthEngineAdapter()
+        spyPlayKey = spyk(PlayKey(fakeSynthEngineAdapter))
+        spyStopKeys = spyk(StopKeys(fakeSynthEngineAdapter))
+    }
+
+    @Test
+    fun `it emits the keyboard`() {
+        val subject = createSubject()
+
+        assertThat(subject.keyboard.value)
+            .isEqualTo(
+                listOf(
+                    Key(Note.C, 3),
+                    Key(Note.D, 3),
+                    Key(Note.E, 3),
+                    Key(Note.F, 3),
+                    Key(Note.G, 3),
+                    Key(Note.A, 3),
+                    Key(Note.B, 3),
+                    Key(Note.C, 4),
+                    Key(Note.D, 4),
+                    Key(Note.E, 4),
+                    Key(Note.F, 4),
+                    Key(Note.G, 4),
+                    Key(Note.A, 4),
+                    Key(Note.B, 4),
+                    Key(Note.C, 5)
+                )
+            )
+    }
+
+    @Test
+    fun `playKey should call the use case`() {
+        val key = Key(Note.G_SHARP_A_FLAT, 2)
+        val subject = createSubject()
+
+        subject.playKey(key)
+
+        verify { spyPlayKey.execute(key) }
+    }
+
+    @Test
+    fun `stopKeys should call the use case`() {
+        val subject = createSubject()
+
+        subject.stopKeys()
+
+        verify { spyStopKeys.execute() }
+    }
+
+    private fun createSubject(): MainViewModel {
+        return MainViewModel(
+            GetKeyboard(),
+            spyPlayKey,
+            spyStopKeys
+        )
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
@@ -19,7 +18,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
+
     }
 }
 


### PR DESCRIPTION
# Description
Move the device and engine information displayed on the main screen into its own screen called 'About' which is accessible via the options menu.

# What's included
- [x] Introduce MVVM architecture
- [x] Add Android navigation component
- [x] Add options menu
- [x] Fix: close audio stream when finished #5

# Screenshots
|1|2|3|
-|-|-
![Screenshot_20200217_162949_com flatmapdev synth](https://user-images.githubusercontent.com/4940864/74671794-d8615d00-51a3-11ea-8e68-82ae36c5df00.jpg)|![Screenshot_20200217_162958_com flatmapdev synth](https://user-images.githubusercontent.com/4940864/74671799-dac3b700-51a3-11ea-9fe0-54df3516d343.jpg)|![Screenshot_20200217_163004_com flatmapdev synth](https://user-images.githubusercontent.com/4940864/74671809-dd261100-51a3-11ea-92b3-bc20d89485a1.jpg)

