### PR TITLE
Add Android ABI build parameter

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,4 +28,4 @@ jobs:
       with:
         api-level: 29
         script: |
-          ./gradlew cppTest
+          ./gradlew cppTest -Pabi=x86

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,13 +46,14 @@ android {
 }
 
 task cppTest {
+    String abi = project.getProperties().getOrDefault('abi', 'x86')
     doLast {
         exec {
-            workingDir './.cxx/cmake/debug/x86'
+            workingDir "./.cxx/cmake/debug/$abi"
             commandLine 'chmod', '+x', './cpp_test_runner.sh'
         }
         exec {
-            workingDir './.cxx/cmake/debug/x86'
+            workingDir "./.cxx/cmake/debug/$abi"
             commandLine './cpp_test_runner.sh'
         }
     }


### PR DESCRIPTION
# Description
Add a parameter to the Gradle build to change the ABI used for C++ unit tests.
https://developer.android.com/ndk/guides/abis

# Usage
```
./gradlew cppTest -Pabi=<abi>
```
For example
```
./gradlew cppTest -Pabi=arm64-v8a
```