### PR TITLE
Fix issue with stream lifecycle during device rotation

### DIFF
--- a/app/src/main/cpp/AudioStream.cpp
+++ b/app/src/main/cpp/AudioStream.cpp
@@ -31,14 +31,17 @@ synth::AudioStream::AudioStream() {
     }
 }
 
-void synth::AudioStream::start(SignalSource &audioSource) {
-    audioSource_ = &audioSource;
+void synth::AudioStream::start() {
     oboeStream_->requestStart();
 }
 
 oboe::DataCallbackResult
 synth::AudioStream::onAudioReady(oboe::AudioStream *audioStream, void *audioData,
                                  int32_t numFrames) {
+    if (audioSource_ == nullptr) {
+        return oboe::DataCallbackResult::Continue;
+    }
+
     // We requested AudioFormat::Float so we assume we got it.
     // For production code always check what format
     // the stream has and cast to the appropriate type.
@@ -55,4 +58,8 @@ int synth::AudioStream::getSampleRate() {
 
 void synth::AudioStream::close() {
     oboeStream_->close();
+}
+
+void synth::AudioStream::setAudioSource(synth::SignalSource &audioSource) {
+    audioSource_ = &audioSource;
 }

--- a/app/src/main/cpp/AudioStream.h
+++ b/app/src/main/cpp/AudioStream.h
@@ -10,9 +10,11 @@ namespace synth {
     public:
         AudioStream();
 
-        void start(SignalSource &audioSource);
+        void start();
 
         void close();
+
+        void setAudioSource(SignalSource &audioSource);
 
         int getSampleRate();
 

--- a/app/src/main/java/com/flatmapdev/synth/mainUi/MainActivity.kt
+++ b/app/src/main/java/com/flatmapdev/synth/mainUi/MainActivity.kt
@@ -24,13 +24,16 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         super.onCreate(savedInstanceState)
 
         NavigationUI.setupActionBarWithNavController(this, navController)
+    }
 
+    override fun onResume() {
+        super.onResume()
         synthEngineAdapter.start()
     }
 
-    override fun onDestroy() {
+    override fun onPause() {
         synthEngineAdapter.stop()
-        super.onDestroy()
+        super.onPause()
     }
 
     override fun onSupportNavigateUp(): Boolean {


### PR DESCRIPTION
This fixes a bug where the audio is killed when the app is paused or the Activity is recreated.

The new behaviour is that
- a new Oboe stream is created when the Activity is resumed (or created)
- the Oboe stream is closed when the Activity is paused