### PR TITLE
Improve design of toolbars, titles and control menu

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -131,6 +131,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'io.mockk:mockk:1.9'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.4'
+    testImplementation "androidx.navigation:navigation-testing:$nav_version"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
@@ -6,6 +6,8 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.NavigationUI
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
@@ -30,7 +32,7 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
+        NavigationUI.setupWithNavController(toolbar, findNavController())
         viewModel.engineVersion.observe(viewLifecycleOwner, Observer { value ->
             engineVersion.text = getString(
                 R.string.app_engine_version, value

--- a/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
@@ -11,8 +11,8 @@ import androidx.navigation.ui.NavigationUI
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
-import javax.inject.Inject
 import kotlinx.android.synthetic.main.fragment_about.*
+import javax.inject.Inject
 
 class AboutFragment : Fragment(R.layout.fragment_about) {
     @Inject

--- a/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/aboutUi/AboutFragment.kt
@@ -11,8 +11,8 @@ import androidx.navigation.ui.NavigationUI
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
-import kotlinx.android.synthetic.main.fragment_about.*
 import javax.inject.Inject
+import kotlinx.android.synthetic.main.fragment_about.*
 
 class AboutFragment : Fragment(R.layout.fragment_about) {
     @Inject

--- a/app/src/main/java/com/flatmapdev/synth/ampEnvelopeUi/AmpEnvelopeFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/ampEnvelopeUi/AmpEnvelopeFragment.kt
@@ -14,8 +14,8 @@ import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.engineCore.model.Envelope
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
-import kotlinx.android.synthetic.main.fragment_amp_envelope.*
 import javax.inject.Inject
+import kotlinx.android.synthetic.main.fragment_amp_envelope.*
 
 class AmpEnvelopeFragment : Fragment(R.layout.fragment_amp_envelope) {
     @Inject

--- a/app/src/main/java/com/flatmapdev/synth/ampEnvelopeUi/AmpEnvelopeFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/ampEnvelopeUi/AmpEnvelopeFragment.kt
@@ -8,6 +8,8 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.NavigationUI
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.engineCore.model.Envelope
@@ -36,6 +38,7 @@ class AmpEnvelopeFragment : Fragment(R.layout.fragment_amp_envelope) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        NavigationUI.setupWithNavController(toolbar, findNavController())
         ampEnvelopeViewModel.init()
         ampEnvelopeViewModel.ampEnvelope.observe(viewLifecycleOwner, Observer { envelope ->
             setAmpEnvelopeValues(envelope)

--- a/app/src/main/java/com/flatmapdev/synth/ampEnvelopeUi/AmpEnvelopeFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/ampEnvelopeUi/AmpEnvelopeFragment.kt
@@ -14,8 +14,8 @@ import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.engineCore.model.Envelope
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
-import javax.inject.Inject
 import kotlinx.android.synthetic.main.fragment_amp_envelope.*
+import javax.inject.Inject
 
 class AmpEnvelopeFragment : Fragment(R.layout.fragment_amp_envelope) {
     @Inject

--- a/app/src/main/java/com/flatmapdev/synth/controlPanelUi/ControlPanelFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/controlPanelUi/ControlPanelFragment.kt
@@ -2,15 +2,21 @@ package com.flatmapdev.synth.controlPanelUi
 
 import android.content.Context
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.NavigationUI
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.oscillatorCore.model.OscillatorId
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
+import com.flatmapdev.synth.synthUi.SynthFragmentDirections
 import javax.inject.Inject
 import kotlinx.android.synthetic.main.fragment_control_panel.*
 
@@ -31,17 +37,24 @@ class ControlPanelFragment : Fragment(R.layout.fragment_control_panel) {
         applyTransitions()
     }
 
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        (activity as AppCompatActivity).setSupportActionBar(toolbar)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        ampEnvelopeControls.setOnClickListener { navigateToAmpEnvelope() }
+        NavigationUI.setupWithNavController(toolbar, findNavController())
+
+        ampEnvelopeTitle.setOnClickListener { navigateToAmpEnvelope() }
 
         osc1Title.text = getString(R.string.osc_title, OscillatorId.Osc1.number)
-        osc1Controls.setOnClickListener { navigateToOscillator1() }
+        osc1Title.setOnClickListener { navigateToOscillator1() }
 
         osc2Title.text = getString(R.string.osc_title, OscillatorId.Osc2.number)
-        osc2Controls.setOnClickListener { navigateToOscillator2() }
+        osc2Title.setOnClickListener { navigateToOscillator2() }
 
-        keyboardControls.setOnClickListener { navigateToKeyboard() }
+        keyboardTitle.setOnClickListener { navigateToKeyboard() }
     }
 
     private fun navigateToAmpEnvelope() {
@@ -70,6 +83,27 @@ class ControlPanelFragment : Fragment(R.layout.fragment_control_panel) {
     private fun navigateToKeyboard() {
         findNavController().navigate(
             ControlPanelFragmentDirections.actionControlPanelFragmentToKeyboardFragment()
+        )
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_main, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.about -> {
+                navigateToAbout()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun navigateToAbout() {
+        parentFragment?.findNavController()?.navigate(
+            SynthFragmentDirections.actionSynthFragmentToAboutFragment()
         )
     }
 }

--- a/app/src/main/java/com/flatmapdev/synth/controlPanelUi/ControlPanelFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/controlPanelUi/ControlPanelFragment.kt
@@ -17,8 +17,8 @@ import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.oscillatorCore.model.OscillatorId
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
 import com.flatmapdev.synth.synthUi.SynthFragmentDirections
-import kotlinx.android.synthetic.main.fragment_control_panel.*
 import javax.inject.Inject
+import kotlinx.android.synthetic.main.fragment_control_panel.*
 
 class ControlPanelFragment : Fragment(R.layout.fragment_control_panel) {
     @Inject

--- a/app/src/main/java/com/flatmapdev/synth/controlPanelUi/ControlPanelFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/controlPanelUi/ControlPanelFragment.kt
@@ -2,9 +2,6 @@ package com.flatmapdev.synth.controlPanelUi
 
 import android.content.Context
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
@@ -16,7 +13,6 @@ import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.oscillatorCore.model.OscillatorId
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
-import com.flatmapdev.synth.synthUi.SynthFragmentDirections
 import javax.inject.Inject
 import kotlinx.android.synthetic.main.fragment_control_panel.*
 
@@ -83,27 +79,6 @@ class ControlPanelFragment : Fragment(R.layout.fragment_control_panel) {
     private fun navigateToKeyboard() {
         findNavController().navigate(
             ControlPanelFragmentDirections.actionControlPanelFragmentToKeyboardFragment()
-        )
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.menu_main, menu)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.about -> {
-                navigateToAbout()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-
-    private fun navigateToAbout() {
-        parentFragment?.findNavController()?.navigate(
-            SynthFragmentDirections.actionSynthFragmentToAboutFragment()
         )
     }
 }

--- a/app/src/main/java/com/flatmapdev/synth/controlPanelUi/ControlPanelFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/controlPanelUi/ControlPanelFragment.kt
@@ -17,8 +17,8 @@ import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.oscillatorCore.model.OscillatorId
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
 import com.flatmapdev.synth.synthUi.SynthFragmentDirections
-import javax.inject.Inject
 import kotlinx.android.synthetic.main.fragment_control_panel.*
+import javax.inject.Inject
 
 class ControlPanelFragment : Fragment(R.layout.fragment_control_panel) {
     @Inject
@@ -39,7 +39,7 @@ class ControlPanelFragment : Fragment(R.layout.fragment_control_panel) {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        (activity as AppCompatActivity).setSupportActionBar(toolbar)
+        (activity as? AppCompatActivity)?.setSupportActionBar(toolbar)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/flatmapdev/synth/keyboardUi/KeyboardFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/keyboardUi/KeyboardFragment.kt
@@ -17,8 +17,8 @@ import com.flatmapdev.synth.keyboardCore.model.ScaleType
 import com.flatmapdev.synth.keyboardShared.toUiString
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
 import com.flatmapdev.synth.shared.ui.util.setDropDownItems
-import javax.inject.Inject
 import kotlinx.android.synthetic.main.fragment_keyboard.*
+import javax.inject.Inject
 
 class KeyboardFragment : Fragment(R.layout.fragment_keyboard) {
     @Inject

--- a/app/src/main/java/com/flatmapdev/synth/keyboardUi/KeyboardFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/keyboardUi/KeyboardFragment.kt
@@ -17,8 +17,8 @@ import com.flatmapdev.synth.keyboardCore.model.ScaleType
 import com.flatmapdev.synth.keyboardShared.toUiString
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
 import com.flatmapdev.synth.shared.ui.util.setDropDownItems
-import kotlinx.android.synthetic.main.fragment_keyboard.*
 import javax.inject.Inject
+import kotlinx.android.synthetic.main.fragment_keyboard.*
 
 class KeyboardFragment : Fragment(R.layout.fragment_keyboard) {
     @Inject

--- a/app/src/main/java/com/flatmapdev/synth/keyboardUi/KeyboardFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/keyboardUi/KeyboardFragment.kt
@@ -8,6 +8,8 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.NavigationUI
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.keyboardCore.model.Note
@@ -37,6 +39,7 @@ class KeyboardFragment : Fragment(R.layout.fragment_keyboard) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        NavigationUI.setupWithNavController(toolbar, findNavController())
         viewModel.init()
         viewModel.scale.observe(viewLifecycleOwner, Observer {
             scaleTonic.setText(getString(it.tonic.toUiString()), false)

--- a/app/src/main/java/com/flatmapdev/synth/mainUi/MainActivity.kt
+++ b/app/src/main/java/com/flatmapdev/synth/mainUi/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.ui.NavigationUI
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.engineCore.adapter.SynthEngineAdapter
@@ -26,8 +25,6 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         (applicationContext as App).appComponent.inject(this)
 
         super.onCreate(savedInstanceState)
-
-        NavigationUI.setupActionBarWithNavController(this, navController)
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/flatmapdev/synth/oscillatorUi/OscillatorFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/oscillatorUi/OscillatorFragment.kt
@@ -17,8 +17,8 @@ import com.flatmapdev.synth.oscillatorCore.model.Oscillator
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
 import com.flatmapdev.synth.shared.ui.util.getProgressFromMiddle
 import com.flatmapdev.synth.shared.ui.util.setProgressFromMiddle
-import javax.inject.Inject
 import kotlinx.android.synthetic.main.fragment_oscillator.*
+import javax.inject.Inject
 
 class OscillatorFragment : Fragment(R.layout.fragment_oscillator) {
     @Inject

--- a/app/src/main/java/com/flatmapdev/synth/oscillatorUi/OscillatorFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/oscillatorUi/OscillatorFragment.kt
@@ -17,8 +17,8 @@ import com.flatmapdev.synth.oscillatorCore.model.Oscillator
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
 import com.flatmapdev.synth.shared.ui.util.getProgressFromMiddle
 import com.flatmapdev.synth.shared.ui.util.setProgressFromMiddle
-import kotlinx.android.synthetic.main.fragment_oscillator.*
 import javax.inject.Inject
+import kotlinx.android.synthetic.main.fragment_oscillator.*
 
 class OscillatorFragment : Fragment(R.layout.fragment_oscillator) {
     @Inject

--- a/app/src/main/java/com/flatmapdev/synth/oscillatorUi/OscillatorFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/oscillatorUi/OscillatorFragment.kt
@@ -4,12 +4,13 @@ import android.content.Context
 import android.os.Bundle
 import android.view.View
 import android.widget.SeekBar
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.navigation.ui.NavigationUI
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.oscillatorCore.model.Oscillator
@@ -38,14 +39,10 @@ class OscillatorFragment : Fragment(R.layout.fragment_oscillator) {
         applyTransitions()
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        (activity as? AppCompatActivity)?.supportActionBar
-            ?.title = getString(R.string.osc_title, args.oscillatorId.number)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        NavigationUI.setupWithNavController(toolbar, findNavController())
+        toolbar.title = getString(R.string.osc_title, args.oscillatorId.number)
         oscillatorViewModel.init(args.oscillatorId)
         oscillatorViewModel.oscillator.observe(viewLifecycleOwner, Observer {
             oscControlsPitchSeekBar.setProgressFromMiddle(it.pitchOffset)
@@ -55,7 +52,6 @@ class OscillatorFragment : Fragment(R.layout.fragment_oscillator) {
     }
 
     private fun setUpOscillatorControls() {
-        oscControlsTitle.text = getString(R.string.osc_title, args.oscillatorId.number)
         oscControlsPitchSeekBar.setOnSeekBarChangeListener(object :
             SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {

--- a/app/src/main/java/com/flatmapdev/synth/synthUi/SynthFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/synthUi/SynthFragment.kt
@@ -6,7 +6,6 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -14,7 +13,6 @@ import androidx.lifecycle.get
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.ui.NavigationUI
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.keyboardCore.model.Key
@@ -50,10 +48,7 @@ class SynthFragment : Fragment(R.layout.fragment_synth) {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        (activity as? AppCompatActivity)?.let { appCompatActivity ->
-            NavigationUI.setupActionBarWithNavController(appCompatActivity, navController)
-        }
-
+        setHasOptionsMenu(true)
         /**
          * This statement is a workaround for a bug which occurs while testing this
          * Fragment inside a FragmentScenario (i.e. launchFragmentInContainer<SynthFragment>()).

--- a/app/src/main/java/com/flatmapdev/synth/synthUi/SynthFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/synthUi/SynthFragment.kt
@@ -17,8 +17,8 @@ import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.keyboardCore.model.Key
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
-import kotlinx.android.synthetic.main.fragment_synth.*
 import javax.inject.Inject
+import kotlinx.android.synthetic.main.fragment_synth.*
 
 class SynthFragment : Fragment(R.layout.fragment_synth) {
     @Inject

--- a/app/src/main/java/com/flatmapdev/synth/synthUi/SynthFragment.kt
+++ b/app/src/main/java/com/flatmapdev/synth/synthUi/SynthFragment.kt
@@ -17,8 +17,8 @@ import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.App
 import com.flatmapdev.synth.keyboardCore.model.Key
 import com.flatmapdev.synth.shared.ui.util.applyTransitions
-import javax.inject.Inject
 import kotlinx.android.synthetic.main.fragment_synth.*
+import javax.inject.Inject
 
 class SynthFragment : Fragment(R.layout.fragment_synth) {
     @Inject

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -1,41 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".mainUi.MainActivity">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/engineVersion"
-        android:layout_width="wrap_content"
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Debug text" />
+        android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
+        app:title="@string/about_title" />
 
-    <TextView
-        android:id="@+id/lowLatencyStatus"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/engineVersion"
-        tools:text="Supports low latency: true" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".mainUi.MainActivity">
 
-    <TextView
-        android:id="@+id/proLatencyStatus"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.498"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/lowLatencyStatus"
-        tools:text="Supports pro latency: false" />
+        <TextView
+            android:id="@+id/engineVersion"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Debug text" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/lowLatencyStatus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/engineVersion"
+            tools:text="Supports low latency: true" />
 
+        <TextView
+            android:id="@+id/proLatencyStatus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.498"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/lowLatencyStatus"
+            tools:text="Supports pro latency: false" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_amp_envelope.xml
+++ b/app/src/main/res/layout/fragment_amp_envelope.xml
@@ -9,7 +9,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:title="@string/osc_title" />
+        app:title="@string/amp_envelope_title" />
 
     <androidx.cardview.widget.CardView
         android:id="@+id/ampEnvelopeControls"

--- a/app/src/main/res/layout/fragment_amp_envelope.xml
+++ b/app/src/main/res/layout/fragment_amp_envelope.xml
@@ -1,69 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/ampEnvelopeControls"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="8dp"
-    app:contentPadding="8dp">
+    android:orientation="vertical">
 
-    <LinearLayout
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        app:title="@string/osc_title" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/amp_envelope_title"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5" />
+    <androidx.cardview.widget.CardView
+        android:id="@+id/ampEnvelopeControls"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        app:contentPadding="8dp">
 
-        <TextView
-            android:id="@+id/ampEnvelopeControlsAttackTitle"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/amp_envelope_attack"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-        <SeekBar
-            android:id="@+id/ampEnvelopeControlsAttackSeekBar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            <TextView
+                android:id="@+id/ampEnvelopeControlsAttackTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/amp_envelope_attack"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
 
-        <TextView
-            android:id="@+id/ampEnvelopeControlsDecayTitle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/amp_envelope_decay"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+            <SeekBar
+                android:id="@+id/ampEnvelopeControlsAttackSeekBar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-        <SeekBar
-            android:id="@+id/ampEnvelopeControlsDecaySeekBar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            <TextView
+                android:id="@+id/ampEnvelopeControlsDecayTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/amp_envelope_decay"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
 
-        <TextView
-            android:id="@+id/ampEnvelopeControlsSustain"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/amp_envelope_sustain"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+            <SeekBar
+                android:id="@+id/ampEnvelopeControlsDecaySeekBar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-        <SeekBar
-            android:id="@+id/ampEnvelopeControlsSustainSeekBar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            <TextView
+                android:id="@+id/ampEnvelopeControlsSustain"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/amp_envelope_sustain"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
 
-        <TextView
-            android:id="@+id/ampEnvelopeControlsReleaseTitle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/amp_envelope_release"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+            <SeekBar
+                android:id="@+id/ampEnvelopeControlsSustainSeekBar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-        <SeekBar
-            android:id="@+id/ampEnvelopeControlsReleaseSeekBar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-    </LinearLayout>
-</androidx.cardview.widget.CardView>
+            <TextView
+                android:id="@+id/ampEnvelopeControlsReleaseTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/amp_envelope_release"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+            <SeekBar
+                android:id="@+id/ampEnvelopeControlsReleaseSeekBar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_control_panel.xml
+++ b/app/src/main/res/layout/fragment_control_panel.xml
@@ -1,84 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/controls"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".mainUi.MainActivity">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:clipToPadding="false"
-        android:orientation="vertical"
-        android:paddingBottom="8dp">
+        android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
+        app:title="@string/osc_title" />
 
-        <androidx.cardview.widget.CardView
-            android:id="@+id/ampEnvelopeControls"
+    <ScrollView
+        android:id="@+id/controls"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        tools:context=".mainUi.MainActivity">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            app:contentPadding="8dp">
+            android:clipToPadding="false"
+            android:orientation="vertical"
+            android:paddingBottom="8dp">
 
             <TextView
                 android:id="@+id/ampEnvelopeTitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/amp_envelope_title" />
-
-        </androidx.cardview.widget.CardView>
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/osc1Controls"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            app:contentPadding="8dp">
+                android:background="?selectableItemBackground"
+                android:padding="16dp"
+                android:text="@string/amp_envelope_title"
+                android:textAppearance="?attr/textAppearanceSubtitle1" />
 
             <TextView
                 android:id="@+id/osc1Title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/osc_title" />
-        </androidx.cardview.widget.CardView>
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/osc2Controls"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            app:contentPadding="8dp">
+                android:background="?selectableItemBackground"
+                android:padding="16dp"
+                android:text="@string/osc_title"
+                android:textAppearance="?attr/textAppearanceSubtitle1" />
 
             <TextView
                 android:id="@+id/osc2Title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/osc_title" />
-        </androidx.cardview.widget.CardView>
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/keyboardControls"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            app:contentPadding="8dp">
+                android:background="?selectableItemBackground"
+                android:padding="16dp"
+                android:text="@string/osc_title"
+                android:textAppearance="?attr/textAppearanceSubtitle1" />
 
             <TextView
                 android:id="@+id/keyboardTitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/keyboard_title" />
-        </androidx.cardview.widget.CardView>
-    </LinearLayout>
-</ScrollView>
+                android:background="?selectableItemBackground"
+                android:padding="16dp"
+                android:text="@string/keyboard_title"
+                android:textAppearance="?attr/textAppearanceSubtitle1" />
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_control_panel.xml
+++ b/app/src/main/res/layout/fragment_control_panel.xml
@@ -13,7 +13,7 @@
         android:background="?attr/colorPrimary"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        app:title="@string/osc_title" />
+        app:title="@string/synth_title" />
 
     <ScrollView
         android:id="@+id/controls"
@@ -44,8 +44,8 @@
                 android:layout_height="wrap_content"
                 android:background="?selectableItemBackground"
                 android:padding="16dp"
-                android:text="@string/osc_title"
-                android:textAppearance="?attr/textAppearanceSubtitle1" />
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                tools:text="@string/osc_title" />
 
             <TextView
                 android:id="@+id/osc2Title"
@@ -53,8 +53,8 @@
                 android:layout_height="wrap_content"
                 android:background="?selectableItemBackground"
                 android:padding="16dp"
-                android:text="@string/osc_title"
-                android:textAppearance="?attr/textAppearanceSubtitle1" />
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                tools:text="@string/osc_title" />
 
             <TextView
                 android:id="@+id/keyboardTitle"

--- a/app/src/main/res/layout/fragment_keyboard.xml
+++ b/app/src/main/res/layout/fragment_keyboard.xml
@@ -1,61 +1,64 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/keyboardControls"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="8dp"
-    app:contentPadding="8dp">
+    android:orientation="vertical">
 
-    <LinearLayout
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        app:title="@string/osc_title" />
 
-        <TextView
-            android:id="@+id/keyboardControlsTitle"
+    <androidx.cardview.widget.CardView
+        android:id="@+id/keyboardControls"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        app:contentPadding="8dp">
+
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
-            android:text="@string/keyboard_title"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5" />
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/scaleTonicLayout"
-            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense.ExposedDropdownMenu"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
-            android:hint="@string/keyboard_scale_tonic"
-            android:labelFor="@id/scaleTonic">
-
-            <AutoCompleteTextView
-                android:id="@+id/scaleTonic"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/scaleTonicLayout"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense.ExposedDropdownMenu"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:editable="false"
-                tools:ignore="Deprecated" />
+                android:layout_marginBottom="8dp"
+                android:hint="@string/keyboard_scale_tonic"
+                android:labelFor="@id/scaleTonic">
 
-        </com.google.android.material.textfield.TextInputLayout>
+                <AutoCompleteTextView
+                    android:id="@+id/scaleTonic"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:editable="false"
+                    tools:ignore="Deprecated" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/scaleTypeLayout"
-            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense.ExposedDropdownMenu"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/keyboard_scale_type"
-            android:labelFor="@id/scaleType">
+            </com.google.android.material.textfield.TextInputLayout>
 
-            <AutoCompleteTextView
-                android:id="@+id/scaleType"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/scaleTypeLayout"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense.ExposedDropdownMenu"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:editable="false"
-                tools:ignore="Deprecated" />
+                android:hint="@string/keyboard_scale_type"
+                android:labelFor="@id/scaleType">
 
-        </com.google.android.material.textfield.TextInputLayout>
+                <AutoCompleteTextView
+                    android:id="@+id/scaleType"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:editable="false"
+                    tools:ignore="Deprecated" />
 
-    </LinearLayout>
-</androidx.cardview.widget.CardView>
+            </com.google.android.material.textfield.TextInputLayout>
 
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_keyboard.xml
+++ b/app/src/main/res/layout/fragment_keyboard.xml
@@ -10,7 +10,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:title="@string/osc_title" />
+        app:title="@string/keyboard_title" />
 
     <androidx.cardview.widget.CardView
         android:id="@+id/keyboardControls"

--- a/app/src/main/res/layout/fragment_oscillator.xml
+++ b/app/src/main/res/layout/fragment_oscillator.xml
@@ -1,37 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/oscControls"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="8dp"
-    app:contentPadding="8dp">
+    android:orientation="vertical">
 
-    <LinearLayout
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        app:title="@string/osc_title" />
 
-        <TextView
-            android:id="@+id/oscControlsTitle"
+    <androidx.cardview.widget.CardView
+        android:id="@+id/oscControls"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        app:contentPadding="8dp">
+
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5"
-            tools:text="Oscillator 1" />
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/oscControlsPitch"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/osc_pitch_offset"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+            <TextView
+                android:id="@+id/oscControlsPitch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/osc_pitch_offset"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
 
-        <SeekBar
-            android:id="@+id/oscControlsPitchSeekBar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            <SeekBar
+                android:id="@+id/oscControlsPitchSeekBar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
-    </LinearLayout>
-</androidx.cardview.widget.CardView>
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+</LinearLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/primaryColor</item>
         <item name="colorPrimaryDark">@color/primaryDarkColor</item>

--- a/app/src/test/java/com/flatmapdev/synth/aboutUi/AboutFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/aboutUi/AboutFragmentTest.kt
@@ -1,6 +1,5 @@
 package com.flatmapdev.synth.aboutUi
 
-import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -14,6 +13,8 @@ import com.flatmapdev.synth.doubles.device.adapter.StubDeviceFeaturesAdapter
 import com.flatmapdev.synth.doubles.device.model.createDeviceFeatures
 import com.flatmapdev.synth.doubles.jni.FakeJniModule
 import com.flatmapdev.synth.doubles.jni.FakeSynth
+import com.flatmapdev.synth.utils.NavControllerFragmentFactory
+import com.flatmapdev.synth.utils.launchAndSetUpFragment
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,8 +37,7 @@ class AboutFragmentTest {
                 )
             )
         )
-        getApp().appComponent = testComponentBuilder.build()
-        launchFragmentInContainer<AboutFragment>()
+        launch()
 
         onView(withId(R.id.engineVersion))
             .check(matches(withText("Engine version: 1.2.345")))
@@ -45,7 +45,7 @@ class AboutFragmentTest {
 
     @Test
     fun `it shows the low latency support`() {
-        getApp().appComponent = testComponentBuilder
+        testComponentBuilder
             .fakeDeviceDataModule(
                 FakeDeviceDataModule(
                     deviceFeaturesAdapter = StubDeviceFeaturesAdapter(
@@ -54,16 +54,15 @@ class AboutFragmentTest {
                         )
                     )
                 )
-            ).build()
-        launchFragmentInContainer<AboutFragment>()
-
+            )
+        launch()
         onView(withId(R.id.lowLatencyStatus))
             .check(matches(withText("Supports low latency: true")))
     }
 
     @Test
     fun `it shows the pro latency support`() {
-        getApp().appComponent = testComponentBuilder
+        testComponentBuilder
             .fakeDeviceDataModule(
                 FakeDeviceDataModule(
                     deviceFeaturesAdapter = StubDeviceFeaturesAdapter(
@@ -72,10 +71,23 @@ class AboutFragmentTest {
                         )
                     )
                 )
-            ).build()
-        launchFragmentInContainer<AboutFragment>()
+            )
+
+        launch()
 
         onView(withId(R.id.proLatencyStatus))
             .check(matches(withText("Supports pro latency: true")))
+    }
+
+    private fun launch() {
+        val fragmentFactory = NavControllerFragmentFactory(
+            R.navigation.main_nav_graph,
+            R.id.aboutFragment
+        )
+
+        getApp().appComponent = testComponentBuilder.build()
+        launchAndSetUpFragment<AboutFragment>(
+            fragmentFactory = fragmentFactory
+        )
     }
 }

--- a/app/src/test/java/com/flatmapdev/synth/ampEnvelopeUi/AmpEnvelopeFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/ampEnvelopeUi/AmpEnvelopeFragmentTest.kt
@@ -1,6 +1,5 @@
 package com.flatmapdev.synth.ampEnvelopeUi
 
-import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -13,6 +12,8 @@ import com.flatmapdev.synth.app.di.DaggerTestAppComponent
 import com.flatmapdev.synth.app.getApp
 import com.flatmapdev.synth.doubles.jni.FakeJniModule
 import com.flatmapdev.synth.doubles.jni.FakeSynth
+import com.flatmapdev.synth.utils.NavControllerFragmentFactory
+import com.flatmapdev.synth.utils.launchAndSetUpFragment
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Before
@@ -31,12 +32,11 @@ class AmpEnvelopeFragmentTest {
     @Test
     fun `when a amp envelope is changed, it sends the new envelope to the synth engine`() {
         val spySynth = spyk(FakeSynth())
-        getApp().appComponent = testComponentBuilder
+        testComponentBuilder
             .fakeJniModule(
                 FakeJniModule(synth = spySynth)
             )
-            .build()
-        launchFragmentInContainer<AmpEnvelopeFragment>()
+        launch()
 
         onView(withId(R.id.ampEnvelopeControlsAttackSeekBar))
             .perform(click())
@@ -54,8 +54,7 @@ class AmpEnvelopeFragmentTest {
 
     @Test
     fun `it displays the amp envelope title`() {
-        getApp().appComponent = testComponentBuilder.build()
-        launchFragmentInContainer<AmpEnvelopeFragment>()
+        launch()
 
         onView(withText(R.string.amp_envelope_title))
             .check(matches(isDisplayed()))
@@ -63,8 +62,7 @@ class AmpEnvelopeFragmentTest {
 
     @Test
     fun `it displays the amp envelope attack control`() {
-        getApp().appComponent = testComponentBuilder.build()
-        launchFragmentInContainer<AmpEnvelopeFragment>()
+        launch()
 
         onView(withText(R.string.amp_envelope_attack))
             .check(matches(isDisplayed()))
@@ -74,8 +72,7 @@ class AmpEnvelopeFragmentTest {
 
     @Test
     fun `it displays the amp envelope decay control`() {
-        getApp().appComponent = testComponentBuilder.build()
-        launchFragmentInContainer<AmpEnvelopeFragment>()
+        launch()
 
         onView(withText(R.string.amp_envelope_decay))
             .check(matches(isDisplayed()))
@@ -85,9 +82,7 @@ class AmpEnvelopeFragmentTest {
 
     @Test
     fun `it displays the amp envelope sustain control`() {
-        getApp().appComponent = testComponentBuilder.build()
-        launchFragmentInContainer<AmpEnvelopeFragment>()
-
+        launch()
         onView(withText(R.string.amp_envelope_sustain))
             .check(matches(isDisplayed()))
         onView(withId(R.id.ampEnvelopeControlsSustainSeekBar))
@@ -96,12 +91,23 @@ class AmpEnvelopeFragmentTest {
 
     @Test
     fun `it displays the amp envelope release control`() {
-        getApp().appComponent = testComponentBuilder.build()
-        launchFragmentInContainer<AmpEnvelopeFragment>()
+        launch()
 
         onView(withText(R.string.amp_envelope_sustain))
             .check(matches(isDisplayed()))
         onView(withId(R.id.ampEnvelopeControlsReleaseSeekBar))
             .check(matches(isDisplayed()))
+    }
+
+    private fun launch() {
+        val fragmentFactory = NavControllerFragmentFactory(
+            R.navigation.synth_nav_graph,
+            R.id.ampEnvelopeFragment
+        )
+
+        getApp().appComponent = testComponentBuilder.build()
+        launchAndSetUpFragment<AmpEnvelopeFragment>(
+            fragmentFactory = fragmentFactory
+        )
     }
 }

--- a/app/src/test/java/com/flatmapdev/synth/controlPanelUi/ControlPanelFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/controlPanelUi/ControlPanelFragmentTest.kt
@@ -1,6 +1,5 @@
 package com.flatmapdev.synth.controlPanelUi
 
-import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -9,6 +8,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flatmapdev.synth.R
 import com.flatmapdev.synth.app.di.DaggerTestAppComponent
 import com.flatmapdev.synth.app.getApp
+import com.flatmapdev.synth.utils.NavControllerFragmentFactory
+import com.flatmapdev.synth.utils.launchAndSetUpFragment
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,32 +22,41 @@ class ControlPanelFragmentTest {
     fun setUp() {
         testComponentBuilder = DaggerTestAppComponent.builder()
         getApp().appComponent = testComponentBuilder.build()
+        val fragmentFactory = NavControllerFragmentFactory(
+            R.navigation.synth_nav_graph,
+            R.id.controlPanelFragment
+        )
+        launchAndSetUpFragment<ControlPanelFragment>(
+            fragmentFactory = fragmentFactory
+        )
+    }
+
+    @Test
+    fun `it displays the title`() {
+        onView(withText(R.string.synth_title))
+            .check(matches(isDisplayed()))
     }
 
     @Test
     fun `it displays the amp envelope`() {
-        launchFragmentInContainer<ControlPanelFragment>()
         onView(withText(R.string.amp_envelope_title))
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun `it displays oscillator 1`() {
-        launchFragmentInContainer<ControlPanelFragment>()
         onView(withText(getApp().getString(R.string.osc_title, 1)))
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun `it displays oscillator 2`() {
-        launchFragmentInContainer<ControlPanelFragment>()
         onView(withText(getApp().getString(R.string.osc_title, 2)))
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun `it displays keyboard`() {
-        launchFragmentInContainer<ControlPanelFragment>()
         onView(withText(R.string.keyboard_title))
             .check(matches(isDisplayed()))
     }

--- a/app/src/test/java/com/flatmapdev/synth/keyboardUi/KeyboardFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/keyboardUi/KeyboardFragmentTest.kt
@@ -1,7 +1,7 @@
 package com.flatmapdev.synth.keyboardUi
 
 import android.widget.AutoCompleteTextView
-import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.fragment.app.testing.FragmentScenario
 import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -19,6 +19,8 @@ import com.flatmapdev.synth.doubles.keyboard.adapter.FakeScaleAdapter
 import com.flatmapdev.synth.keyboardCore.model.Note
 import com.flatmapdev.synth.keyboardCore.model.Scale
 import com.flatmapdev.synth.keyboardCore.model.ScaleType
+import com.flatmapdev.synth.utils.NavControllerFragmentFactory
+import com.flatmapdev.synth.utils.launchAndSetUpFragment
 import com.flatmapdev.synth.utils.skipTextInputLayoutAnimations
 import com.flatmapdev.synth.utils.textInputLayoutwithItemHint
 import io.mockk.spyk
@@ -32,33 +34,35 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class KeyboardFragmentTest {
     private lateinit var testComponentBuilder: DaggerTestAppComponent.Builder
-
     @Before
     fun setUp() {
         testComponentBuilder = DaggerTestAppComponent.builder()
     }
 
     @Test
-    fun `it displays the keyboard scale tonic control`() {
-        getApp().appComponent = testComponentBuilder.build()
-        launchFragmentInContainer<KeyboardFragment>()
+    fun `it displays the title`() {
+        launch()
+        onView(withText(R.string.keyboard_title))
+            .check(matches(isDisplayed()))
+    }
 
+    @Test
+    fun `it displays the keyboard scale tonic control`() {
+        launch()
         onView(withId(R.id.scaleTonicLayout))
             .check(matches(textInputLayoutwithItemHint(getApp().getString(R.string.keyboard_scale_tonic))))
     }
 
     @Test
     fun `it displays the keyboard scale type control`() {
-        getApp().appComponent = testComponentBuilder.build()
-        launchFragmentInContainer<KeyboardFragment>()
-
+        launch()
         onView(withId(R.id.scaleTypeLayout))
             .check(matches(textInputLayoutwithItemHint(getApp().getString(R.string.keyboard_scale_type))))
     }
 
     @Test
     fun `it displays the current scale`() {
-        getApp().appComponent = testComponentBuilder
+        testComponentBuilder = testComponentBuilder
             .fakeKeyboardDataModule(
                 FakeKeyboardDataModule(
                     scaleAdapter = FakeScaleAdapter(
@@ -66,9 +70,7 @@ class KeyboardFragmentTest {
                     )
                 )
             )
-            .build()
-        launchFragmentInContainer<KeyboardFragment>()
-
+        launch()
         onView(withText(R.string.note_g))
             .check(matches(isDisplayed()))
         onView(withText(R.string.scale_type_major))
@@ -82,15 +84,13 @@ class KeyboardFragmentTest {
                 Scale(Note.F, ScaleType.Major)
             )
         )
-        getApp().appComponent = testComponentBuilder
+        testComponentBuilder = testComponentBuilder
             .fakeKeyboardDataModule(
                 FakeKeyboardDataModule(
                     scaleAdapter = spyScaleAdapter
                 )
             )
-            .build()
-        val scenario = launchFragmentInContainer<KeyboardFragment>()
-
+        val scenario = launch()
         scenario.onFragment { fragment ->
             onView(withId(R.id.scaleTonicLayout)).perform(click())
             onView(withId(R.id.scaleTonicLayout)).perform(skipTextInputLayoutAnimations())
@@ -113,5 +113,17 @@ class KeyboardFragmentTest {
             spyScaleAdapter.storeScale(Scale(Note.C_SHARP_D_FLAT, ScaleType.Major))
             spyScaleAdapter.storeScale(Scale(Note.C_SHARP_D_FLAT, ScaleType.HarmonicMinor))
         }
+    }
+
+    private fun launch(): FragmentScenario<KeyboardFragment> {
+        val fragmentFactory = NavControllerFragmentFactory(
+            navGraph = R.navigation.synth_nav_graph,
+            destinationId = R.id.keyboardFragment
+        )
+
+        getApp().appComponent = testComponentBuilder.build()
+        return launchAndSetUpFragment(
+            fragmentFactory = fragmentFactory
+        )
     }
 }

--- a/app/src/test/java/com/flatmapdev/synth/oscillatorUi/OscillatorFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/oscillatorUi/OscillatorFragmentTest.kt
@@ -1,6 +1,5 @@
 package com.flatmapdev.synth.oscillatorUi
 
-import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.swipeRight
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -14,6 +13,8 @@ import com.flatmapdev.synth.app.getApp
 import com.flatmapdev.synth.doubles.jni.FakeJniModule
 import com.flatmapdev.synth.doubles.jni.FakeSynthOscillator
 import com.flatmapdev.synth.oscillatorCore.model.OscillatorId
+import com.flatmapdev.synth.utils.NavControllerFragmentFactory
+import com.flatmapdev.synth.utils.launchAndSetUpFragment
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Before
@@ -23,19 +24,16 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class OscillatorFragmentTest {
     private lateinit var testComponentBuilder: DaggerTestAppComponent.Builder
-
     @Before
     fun setUp() {
         testComponentBuilder = DaggerTestAppComponent.builder()
     }
 
     @Test
-    fun `it displays the oscillator control`() {
-        getApp().appComponent = testComponentBuilder.build()
-        launchFragmentInContainer<OscillatorFragment>(
-            OscillatorFragmentArgs(OscillatorId.Osc1).toBundle()
-        )
+    fun `it displays the oscillator title`() {
         val expectedString = getApp().getString(R.string.osc_title, 1)
+
+        launch()
 
         onView(withText(expectedString))
             .check(matches(isDisplayed()))
@@ -46,14 +44,12 @@ class OscillatorFragmentTest {
     @Test
     fun `when the oscillator pitch is changed, it sends the new oscillator config to the synth engine`() {
         val spySynthOscillator = spyk(FakeSynthOscillator())
-        getApp().appComponent = testComponentBuilder
+        testComponentBuilder = testComponentBuilder
             .fakeJniModule(
                 FakeJniModule(synthOscillator1 = spySynthOscillator)
             )
-            .build()
-        launchFragmentInContainer<OscillatorFragment>(
-            OscillatorFragmentArgs(OscillatorId.Osc1).toBundle()
-        )
+
+        launch()
 
         onView(withId(R.id.oscControlsPitchSeekBar))
             .perform(swipeRight())
@@ -66,14 +62,11 @@ class OscillatorFragmentTest {
     @Test
     fun `when the oscillator pitch is changed, it doesn't update the wrong oscillator in the engine`() {
         val spySynthOscillator = spyk(FakeSynthOscillator())
-        getApp().appComponent = testComponentBuilder
+        testComponentBuilder = testComponentBuilder
             .fakeJniModule(
                 FakeJniModule(synthOscillator2 = spySynthOscillator)
             )
-            .build()
-        launchFragmentInContainer<OscillatorFragment>(
-            OscillatorFragmentArgs(OscillatorId.Osc1).toBundle()
-        )
+        launch()
 
         onView(withId(R.id.oscControlsPitchSeekBar))
             .perform(swipeRight())
@@ -81,5 +74,18 @@ class OscillatorFragmentTest {
         verify(inverse = true) {
             spySynthOscillator.setOscillator(any())
         }
+    }
+
+    private fun launch() {
+        val fragmentFactory = NavControllerFragmentFactory(
+            R.navigation.synth_nav_graph,
+            R.id.oscillatorFragment
+        )
+
+        getApp().appComponent = testComponentBuilder.build()
+        launchAndSetUpFragment<OscillatorFragment>(
+            OscillatorFragmentArgs(OscillatorId.Osc1).toBundle(),
+            fragmentFactory = fragmentFactory
+        )
     }
 }

--- a/app/src/test/java/com/flatmapdev/synth/synthUi/SynthFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/synthUi/SynthFragmentTest.kt
@@ -12,6 +12,7 @@ import com.flatmapdev.synth.app.di.DaggerTestAppComponent
 import com.flatmapdev.synth.app.getApp
 import com.flatmapdev.synth.doubles.jni.FakeJniModule
 import com.flatmapdev.synth.doubles.jni.FakeSynth
+import com.flatmapdev.synth.utils.launchAndSetUpFragment
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Before
@@ -30,7 +31,7 @@ class SynthFragmentTest {
     @Test
     fun `it shows the keyboard`() {
         getApp().appComponent = testComponentBuilder.build()
-        launchFragmentInContainer<SynthFragment>()
+        launchAndSetUpFragment<SynthFragment>()
 
         onView(withId(R.id.keyboard))
             .check(matches(isDisplayed()))
@@ -46,7 +47,7 @@ class SynthFragmentTest {
                 )
             )
             .build()
-        launchFragmentInContainer<SynthFragment>()
+        launchAndSetUpFragment<SynthFragment>()
 
         onView(withId(R.id.keyboard))
             .perform(click())

--- a/app/src/test/java/com/flatmapdev/synth/synthUi/SynthFragmentTest.kt
+++ b/app/src/test/java/com/flatmapdev/synth/synthUi/SynthFragmentTest.kt
@@ -1,6 +1,5 @@
 package com.flatmapdev.synth.synthUi
 
-import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches

--- a/app/src/test/java/com/flatmapdev/synth/utils/LaunchAndSetUpFragment.kt
+++ b/app/src/test/java/com/flatmapdev/synth/utils/LaunchAndSetUpFragment.kt
@@ -1,0 +1,22 @@
+package com.flatmapdev.synth.utils
+
+import android.os.Bundle
+import androidx.annotation.StyleRes
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import androidx.fragment.app.testing.FragmentScenario
+import com.flatmapdev.synth.R
+
+inline fun <reified F : Fragment> launchAndSetUpFragment(
+    fragmentArgs: Bundle? = null,
+    @StyleRes themeResId: Int = R.style.AppTheme,
+    fragmentFactory: FragmentFactory = FragmentFactory()
+): FragmentScenario<F> {
+    return FragmentScenario.launchInContainer(
+        F::class.java,
+        fragmentArgs,
+        themeResId,
+        fragmentFactory
+    )
+}
+

--- a/app/src/test/java/com/flatmapdev/synth/utils/LaunchAndSetUpFragment.kt
+++ b/app/src/test/java/com/flatmapdev/synth/utils/LaunchAndSetUpFragment.kt
@@ -19,4 +19,3 @@ inline fun <reified F : Fragment> launchAndSetUpFragment(
         fragmentFactory
     )
 }
-

--- a/app/src/test/java/com/flatmapdev/synth/utils/NavControllerFragmentFactory.kt
+++ b/app/src/test/java/com/flatmapdev/synth/utils/NavControllerFragmentFactory.kt
@@ -1,0 +1,36 @@
+package com.flatmapdev.synth.utils
+
+import androidx.annotation.IdRes
+import androidx.annotation.NavigationRes
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import androidx.navigation.Navigation
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+
+class NavControllerFragmentFactory(
+    @NavigationRes private val navGraph: Int? = null,
+    @IdRes private val destinationId: Int? = null
+) : FragmentFactory() {
+    override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+        return super.instantiate(classLoader, className).apply {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+
+            if (navGraph != null) {
+                navController.setGraph(navGraph)
+            }
+
+            if (destinationId != null) {
+                navController.setCurrentDestination(destinationId)
+            }
+
+            viewLifecycleOwnerLiveData.observeForever { viewLifecycleOwner ->
+                if (viewLifecycleOwner != null) {
+                    Navigation.setViewNavController(requireView(), navController)
+                }
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,8 @@
 
 buildscript {
     ext.kotlin_version = '1.3.70'
-    ext.nav_version = "2.2.1"
+    // Using alpha version for the TestNavigationController
+    ext.nav_version = "2.3.0-alpha03"
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
# Description
Improve the design of toolbars and titles:
- remove duplicate titles in toolbar and content view
- use light coloured toolbars for child screens of the control panel

Improve design of control menu:
- use the 'single line item' style from material
- add a clickable background animation to the items

# Screenshots
1|2|3
-|-|-
![Screenshot_20200310_161929_com flatmapdev synth](https://user-images.githubusercontent.com/4940864/76334856-954e6180-62eb-11ea-88f0-079ae45f031e.jpg)|![Screenshot_20200310_161938_com flatmapdev synth](https://user-images.githubusercontent.com/4940864/76334853-94b5cb00-62eb-11ea-8d4e-73aaad68906f.jpg)|![Screenshot_20200310_161944_com flatmapdev synth](https://user-images.githubusercontent.com/4940864/76334846-93849e00-62eb-11ea-92fa-37a8d00c477a.jpg)
