### PR TITLE
Fix C++ lint script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ env.ANDROID_NDK_HOME }}
-        key: ${{ runner.os }}-ndk-${{ hashFiles(env.ANDROID_NDK_HOME) }}
+        key: ${{ runner.os }}-ndk-21.0.6113669-cmake-3.10.2.4988404
         restore-keys: |
           ${{ runner.os }}-ndk-
     - name: Setup NDK

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Setup CMake
+      shell: bash
+      run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.10.2.4988404"
     - name: Build
       run: >
         ./gradlew assembleRelease

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -22,6 +22,9 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Setup NDK
+      shell: bash
+      run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669"
     - name: Setup CMake
       shell: bash
       run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.10.2.4988404"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Checkout
-      shell: bash
       run: |
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
@@ -23,7 +22,6 @@ jobs:
       with:
         java-version: 1.8
     - name: Setup NDK
-      shell: bash
       run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"
     - name: Build
       run: >

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,13 +22,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Cache NDK
-      uses: actions/cache@v1
-      with:
-        path: ${{ env.ANDROID_NDK_HOME }}
-        key: ${{ runner.os }}-ndk-21.0.6113669-cmake-3.10.2.4988404
-        restore-keys: |
-          ${{ runner.os }}-ndk-
     - name: Setup NDK
       shell: bash
       run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,12 +22,16 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Cache NDK
+      uses: actions/cache@v1
+      with:
+        path: ${{ env.ANDROID_NDK_HOME }}
+        key: ${{ runner.os }}-ndk-${{ hashFiles(env.ANDROID_NDK_HOME) }}
+        restore-keys: |
+          ${{ runner.os }}-ndk-
     - name: Setup NDK
       shell: bash
-      run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669"
-    - name: Setup CMake
-      shell: bash
-      run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.10.2.4988404"
+      run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"
     - name: Build
       run: >
         ./gradlew assembleRelease

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,16 +13,6 @@ jobs:
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-    - name: Checkout submodules
-      shell: bash
-      run: echo $ANDROID_NDK_HOME
-    - name: Cache NDK
-      uses: actions/cache@v1
-      with:
-        path: $ANDROID_NDK_HOME
-        key: ${{ runner.os }}-ndk-21.0.6113669-cmake-3.10.2.4988404
-        restore-keys: |
-          ${{ runner.os }}-ndk-21.0.6113669-cmake-3.10.2.4988404
     - name: Setup NDK
       shell: bash
       run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"
@@ -45,13 +35,6 @@ jobs:
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-      - name: Cache NDK
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.ANDROID_NDK_HOME }}
-          key: ${{ runner.os }}-ndk-21.0.6113669-cmake-3.10.2.4988404
-          restore-keys: |
-            ${{ runner.os }}-ndk-
       - name: Setup NDK
         shell: bash
         run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Setup CMake
       shell: bash
       run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.10.2.4988404"
-    - name: Add clang-tidy to path
-      run: echo ::set-env name=PATH::$(echo "$(find $ANDROID_NDK_HOME -name "clang-tidy" | xargs dirname):$PATH")
+    - name: Find clang-tidy
+      run: $(find $ANDROID_NDK_HOME -name "clang-tidy") --version
     - name: C++ Lint
       run: ./gradlew cppLint
     - name: Kotlin Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+    - name: Setup NDK
+      shell: bash
+      run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669"
     - name: Setup CMake
       shell: bash
       run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.10.2.4988404"
@@ -35,6 +38,9 @@ jobs:
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+      - name: Setup NDK
+        shell: bash
+        run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669"
       - name: Setup CMake
         shell: bash
         run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.10.2.4988404"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+      - name: Setup CMake
+        shell: bash
+        run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.10.2.4988404"
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,16 @@ jobs:
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+    - name: Cache NDK
+      uses: actions/cache@v1
+      with:
+        path: ${{ env.ANDROID_NDK_HOME }}
+        key: ${{ runner.os }}-ndk-${{ hashFiles(env.ANDROID_NDK_HOME) }}
+        restore-keys: |
+          ${{ runner.os }}-ndk-
     - name: Setup NDK
       shell: bash
-      run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669"
-    - name: Setup CMake
-      shell: bash
-      run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.10.2.4988404"
+      run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"
     - name: Find clang-tidy
       run: $(find $ANDROID_NDK_HOME -name "clang-tidy") --version
     - name: C++ Lint
@@ -38,12 +42,16 @@ jobs:
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+      - name: Cache NDK
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.ANDROID_NDK_HOME }}
+          key: ${{ runner.os }}-ndk-${{ hashFiles(env.ANDROID_NDK_HOME) }}
+          restore-keys: |
+            ${{ runner.os }}-ndk-
       - name: Setup NDK
         shell: bash
-        run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669"
-      - name: Setup CMake
-        shell: bash
-        run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.10.2.4988404"
+        run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,16 @@ jobs:
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+    - name: Checkout submodules
+      shell: bash
+      run: echo $ANDROID_NDK_HOME
     - name: Cache NDK
       uses: actions/cache@v1
       with:
-        path: ${{ env.ANDROID_NDK_HOME }}
+        path: $ANDROID_NDK_HOME
         key: ${{ runner.os }}-ndk-21.0.6113669-cmake-3.10.2.4988404
         restore-keys: |
-          ${{ runner.os }}-ndk-
+          ${{ runner.os }}-ndk-21.0.6113669-cmake-3.10.2.4988404
     - name: Setup NDK
       shell: bash
       run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+    - name: Setup CMake
+      shell: bash
+      run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.10.2.4988404"
     - name: Add clang-tidy to path
       run: echo ::set-env name=PATH::$(echo "$(find $ANDROID_NDK_HOME -name "clang-tidy" | xargs dirname):$PATH")
     - name: C++ Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Checkout submodules
-      shell: bash
       run: |
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
     - name: Setup NDK
-      shell: bash
       run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"
     - name: Find clang-tidy
       run: $(find $ANDROID_NDK_HOME -name "clang-tidy") --version
@@ -30,13 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Checkout submodules
-        shell: bash
         run: |
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Setup NDK
-        shell: bash
         run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"
       - name: set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ env.ANDROID_NDK_HOME }}
-        key: ${{ runner.os }}-ndk-${{ hashFiles(env.ANDROID_NDK_HOME) }}
+        key: ${{ runner.os }}-ndk-21.0.6113669-cmake-3.10.2.4988404
         restore-keys: |
           ${{ runner.os }}-ndk-
     - name: Setup NDK
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.ANDROID_NDK_HOME }}
-          key: ${{ runner.os }}-ndk-${{ hashFiles(env.ANDROID_NDK_HOME) }}
+          key: ${{ runner.os }}-ndk-21.0.6113669-cmake-3.10.2.4988404
           restore-keys: |
             ${{ runner.os }}-ndk-
       - name: Setup NDK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
     - name: Setup NDK
       run: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669" "cmake;3.10.2.4988404"
-    - name: Find clang-tidy
-      run: $(find $ANDROID_NDK_HOME -name "clang-tidy") --version
     - name: C++ Lint
       run: ./gradlew cppLint
     - name: Kotlin Lint

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.10.2)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ android {
             }
         }
     }
+    ndkVersion '21.0.6113669'
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,6 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++14"
-                version "3.10.2"
             }
         }
     }
@@ -62,6 +61,7 @@ android {
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"
+            version "3.10.2"
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,6 @@ apply plugin: 'kotlin-kapt'
 apply plugin: "androidx.navigation.safeargs.kotlin"
 
 def keystorePropertiesFile = project.rootProject.file('keystore.properties')
-def abi = project.getProperties().getOrDefault('abi', 'x86')
 def appVersionCode = Integer.valueOf(project.getProperties().getOrDefault('versionCode', 1))
 def appVersionName = project.getProperties().getOrDefault('versionName', '1.0')
 
@@ -108,6 +107,7 @@ task cppTest {
 }
 
 task cppLint {
+    def abi = project.getProperties().getOrDefault('abi', 'x86')
     doLast {
         exec {
             workingDir "./.cxx/cmake/debug/$abi"

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-
+include(cmake/list_transform.cmake)
 set(SYNTH_ENGINE_SOURCES
         AudioEngine.cpp
         AudioStream.cpp
@@ -41,6 +41,7 @@ android-*,\
 
 set(LINT_RUNNER ${CMAKE_BINARY_DIR}/cpp_lint_runner.sh)
 
+list_transform_prepend(SYNTH_ENGINE_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/")
 add_custom_command(
         TARGET synth-engine POST_BUILD
         VERBATIM COMMAND > ${LINT_RUNNER}

--- a/app/src/main/cpp/Filter.cpp
+++ b/app/src/main/cpp/Filter.cpp
@@ -5,7 +5,7 @@ synth::Filter::Filter(const int sampleRate)
         : sampleRate_{static_cast<float>(sampleRate)} {
     setCutoff(MAX_FREQUENCY);
     setResonance(0.0F);
-    vaStateVariableFilter_.setSampleRate(sampleRate);
+    vaStateVariableFilter_.setSampleRate(sampleRate_);
 }
 
 void synth::Filter::getSignal(std::vector<float> &buffer) {

--- a/app/src/main/cpp/Filter.h
+++ b/app/src/main/cpp/Filter.h
@@ -30,7 +30,7 @@ namespace synth {
         VAStateVariableFilter vaStateVariableFilter_{};
         float sampleRate_;
         bool isActive_{true};
-        float resonance_;
+        float resonance_{};
     };
 
 }

--- a/app/src/main/cpp/cmake/list_transform.cmake
+++ b/app/src/main/cpp/cmake/list_transform.cmake
@@ -1,0 +1,8 @@
+function(list_transform_prepend var prefix)
+    set(temp "")
+    foreach(f ${${var}})
+        list(APPEND temp "${prefix}${f}")
+    endforeach()
+    set(${var} "${temp}" PARENT_SCOPE)
+endfunction()
+

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -1,12 +1,12 @@
 #include "AudioEngine.h"
 #include "AudioStream.h"
 #include "Envelope.h"
+#include "Filter.h"
 #include "NoiseWaveform.h"
 #include "Oscillator.h"
 #include "SineWaveform.h"
 #include "SquareWaveform.h"
 #include "TriangleWaveform.h"
-#include "Filter.h"
 #include <jni.h>
 #include <oboe/Oboe.h>
 #include <string>


### PR DESCRIPTION
Previously the Gradle `cppLint` task was failing silently because the source files could not be found. This was caused by a change to the file paths written to the lint script, from absolute to relative paths.