### PR TITLE
Explicitly register JNI methods at runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,9 @@ jobs:
           api-level: 29
           script: |
             ./gradlew cppTest -Pabi=$(adb shell getprop ro.product.cpu.abi)
+      - name: Connected Android Test
+        uses: ReactiveCircus/android-emulator-runner@v2.4.0
+        with:
+          api-level: 29
+          script: |
+            ./gradlew connectedAndroidTest

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/google/oboe
 [submodule "app/libs/cpp/libnativehelper"]
 	path = app/libs/cpp/libnativehelper/src
-	url = https://android.googlesource.com/platform/libnativehelper
+	url = https://github.com/jonnyandrew/libnativehelper

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "app/libs/cpp/oboe"]
 	path = app/libs/cpp/oboe
 	url = https://github.com/google/oboe
+[submodule "app/libs/cpp/libnativehelper"]
+	path = app/libs/cpp/libnativehelper/src
+	url = https://android.googlesource.com/platform/libnativehelper

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/app/libs/cpp/libnativehelper" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/libs/cpp/oboe" vcs="Git" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/app/libs/cpp/libnativehelper" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/app/libs/cpp/libnativehelper/src" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/libs/cpp/oboe" vcs="Git" />
   </component>
 </project>

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)
 
-add_definitions(-DANDROID)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_subdirectory(libs/cpp)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 
+add_definitions(-DANDROID)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_subdirectory(libs/cpp)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,7 @@ android {
         ]
 
     }
+
     testOptions {
         unitTests {
             includeAndroidResources = true

--- a/app/libs/cpp/CMakeLists.txt
+++ b/app/libs/cpp/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_library(log-lib log)
 
+add_subdirectory(libnativehelper)
 add_subdirectory(oboe)
 add_subdirectory(vasvf)
 

--- a/app/libs/cpp/libnativehelper/CMakeLists.txt
+++ b/app/libs/cpp/libnativehelper/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(libnativehelper)
+
+set(LIBNATIVEHELPER_SOURCES
+        src/JniConstants.cpp
+        src/JNIHelp.cpp
+        )
+
+add_library(libnativehelper ${LIBNATIVEHELPER_SOURCES})
+
+set(CMAKE_CXX_FLAGS "-fPIC")
+set_target_properties(libnativehelper PROPERTIES CMAKE_SHARED_LINKER_FLAGS "-fPIC")
+
+find_library(log-lib liblog)
+target_link_libraries(
+        libnativehelper
+        ${log-lib}
+)
+
+target_include_directories(libnativehelper PUBLIC
+        src/include
+        src/include_jni
+        src/header_only_include
+        src/platform_include
+        )

--- a/app/src/androidTest/java/com/flatmapdev/synth/AppInitializationTest.kt
+++ b/app/src/androidTest/java/com/flatmapdev/synth/AppInitializationTest.kt
@@ -1,0 +1,22 @@
+package com.flatmapdev.synth
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.flatmapdev.synth.mainUi.MainActivity
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class AppInitializationTest {
+    /**
+     * Test that the app starts without crashing. This verifies that the
+     * JNI interface that gets registered by the native library matches the
+     * Kotlin interface.
+     */
+    @Test
+    fun testTheAppInitializesWithoutCrashing() {
+        ActivityScenario.launch(MainActivity::class.java)
+    }
+}

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -2,6 +2,7 @@ include(cmake/list_transform.cmake)
 set(SYNTH_ENGINE_SOURCES
         jni/AmpEnvelopeJni.cpp
         jni/FilterJni.cpp
+        jni/OnLoad.cpp
         jni/OscillatorJni.cpp
         jni/SynthEngineJni.cpp
         jni/model/Synth.cpp

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
 )
 target_link_libraries(
         synth-engine
+        libnativehelper
         oboe
         vasvf
         ${log-lib}

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -40,9 +40,11 @@ android-*,\
 -fuchsia-*,\
 -cppcoreguidelines-pro-bounds-array-to-pointer-decay,\
 -cppcoreguidelines-pro-bounds-pointer-arithmetic,\
+-cppcoreguidelines-pro-type-reinterpret-cast,\
 -cppcoreguidelines-pro-type-vararg,\
 -hicpp-no-array-decay,\
 -hicpp-vararg,\
+-clang-analyzer-core.uninitialized.UndefReturn,\
 -clang-diagnostic-unused-command-line-argument")
 
 set(LINT_RUNNER ${CMAKE_BINARY_DIR}/cpp_lint_runner.sh)

--- a/app/src/main/cpp/jni/AmpEnvelopeJni.cpp
+++ b/app/src/main/cpp/jni/AmpEnvelopeJni.cpp
@@ -34,9 +34,6 @@ namespace jni {
     ) {
         auto synth = &model::Synth::fromPtr(synthPtr);
         ScopedFloatArrayRO envelopeAdsr(env, jEnvelopeAdsr);
-        if (envelopeAdsr.get() == nullptr) {
-            jniThrowNullPointerException(env, "envelope is null");
-        }
         synth::EnvelopeParameters envelopeParameters{
                 envelopeAdsr[0],
                 envelopeAdsr[1],

--- a/app/src/main/cpp/jni/AmpEnvelopeJni.cpp
+++ b/app/src/main/cpp/jni/AmpEnvelopeJni.cpp
@@ -1,5 +1,6 @@
 #include "model/Synth.h"
 #include "../synth/EnvelopeParameters.h"
+#include <nativehelper/ScopedPrimitiveArray.h>
 
 namespace jni {
 
@@ -32,7 +33,10 @@ namespace jni {
             jfloatArray jEnvelopeAdsr
     ) {
         auto synth = &model::Synth::fromPtr(synthPtr);
-        float *envelopeAdsr = env->GetFloatArrayElements(jEnvelopeAdsr, nullptr);
+        ScopedFloatArrayRO envelopeAdsr(env, jEnvelopeAdsr);
+        if (envelopeAdsr.get() == nullptr) {
+            jniThrowNullPointerException(env, "envelope is null");
+        }
         synth::EnvelopeParameters envelopeParameters{
                 envelopeAdsr[0],
                 envelopeAdsr[1],

--- a/app/src/main/cpp/jni/AmpEnvelopeJni.cpp
+++ b/app/src/main/cpp/jni/AmpEnvelopeJni.cpp
@@ -3,10 +3,30 @@
 #include <nativehelper/ScopedPrimitiveArray.h>
 
 namespace jni {
+    auto getAmpEnvelope(JNIEnv *env, jobject /*unused*/, jlong synthPtr) -> jfloatArray;
 
-    extern "C" {
-    JNIEXPORT JNICALL auto
-    Java_com_flatmapdev_synth_jni_NativeSynthEngine_getAmpEnvelope(
+    void setAmpEnvelope(JNIEnv *env, jobject /*unused*/, jlong synthPtr, jfloatArray jEnvelopeAdsr);
+
+    auto registerAmpEnvelopeMethods(JNIEnv *env) -> jint {
+        jclass c = env->FindClass("com/flatmapdev/synth/jni/NativeSynthFilter");
+        if (c == nullptr) { return JNI_ERR; }
+
+        std::vector<JNINativeMethod> methods{
+                {"getAmpEnvelope", "(J)[F",  reinterpret_cast<void *>(jni::getAmpEnvelope)},
+                {"setAmpEnvelope", "(J[F)V", reinterpret_cast<void *>(jni::setAmpEnvelope)}
+        };
+
+        jniRegisterNativeMethods(
+                env,
+                "com/flatmapdev/synth/jni/NativeSynthEngine",
+                methods.data(),
+                methods.size()
+        );
+
+        return JNI_VERSION_1_6;
+    }
+
+    auto getAmpEnvelope(
             JNIEnv *env,
             jobject /* cls */,
             jlong synthPtr
@@ -15,18 +35,17 @@ namespace jni {
         jfloatArray result;
         result = env->NewFloatArray(4);
         auto envelopeParameters = synth->getAmpEnvelope().getEnvelopeParameters();
-        jfloat buffer[4]{
+        std::vector<jfloat> buffer{
                 envelopeParameters.attackTimeMs,
                 envelopeParameters.decayTimeMs,
                 envelopeParameters.sustainLevel,
                 envelopeParameters.releaseTimeMs
         };
-        env->SetFloatArrayRegion(result, 0, 4, buffer);
+        env->SetFloatArrayRegion(result, 0, 4, buffer.data());
         return result;
     }
 
-    JNIEXPORT void JNICALL
-    Java_com_flatmapdev_synth_jni_NativeSynthEngine_setAmpEnvelope(
+    void setAmpEnvelope(
             JNIEnv *env,
             jobject /* cls */,
             jlong synthPtr,
@@ -41,7 +60,5 @@ namespace jni {
                 envelopeAdsr[3]
         };
         synth->getAmpEnvelope().setEnvelopeParameters(envelopeParameters);
-    }
-
     }
 }  // namespace jni

--- a/app/src/main/cpp/jni/AmpEnvelopeJni.h
+++ b/app/src/main/cpp/jni/AmpEnvelopeJni.h
@@ -1,0 +1,10 @@
+#ifndef SYNTH_AMPENVELOPEJNI_H
+#define SYNTH_AMPENVELOPEJNI_H
+
+#include <jni.h>
+
+namespace jni {
+    jint registerAmpEnvelopeMethods(JNIEnv *env);
+} // namespace jni
+
+#endif //SYNTH_AMPENVELOPEJNI_H

--- a/app/src/main/cpp/jni/FilterJni.cpp
+++ b/app/src/main/cpp/jni/FilterJni.cpp
@@ -1,12 +1,39 @@
 #include "model/Synth.h"
 #include <jni.h>
+#include <nativehelper/JNIHelp.h>
 
 namespace jni {
 
-    extern "C" {
+    auto getFilter(JNIEnv *env, jobject /*unused*/, jlong synthPtr) -> jobject;
 
-    JNIEXPORT auto JNICALL
-    Java_com_flatmapdev_synth_jni_NativeSynthFilter_getFilter(
+    void setIsActive(JNIEnv * /*unused*/, jobject /*unused*/, jlong synthPtr, jboolean isActive);
+
+    void setCutoff(JNIEnv * /*unused*/, jobject /*unused*/, jlong synthPtr, jfloat cutoffFrequency);
+
+    void setResonance(JNIEnv * /*unused*/, jobject /*unused*/, jlong synthPtr, jfloat resonance);
+
+    auto registerFilterMethods(JNIEnv *env) -> jint {
+        jclass c = env->FindClass("com/flatmapdev/synth/jni/NativeSynthFilter");
+        if (c == nullptr) { return JNI_ERR; }
+
+        std::vector<JNINativeMethod> methods{
+                {"getFilter",    "(J)Lcom/flatmapdev/synth/filterData/model/FilterData;", reinterpret_cast<void *>(jni::getFilter)},
+                {"setIsActive",  "(JZ)V",                                                 reinterpret_cast<void *>(jni::setIsActive)},
+                {"setCutoff",    "(JF)V",                                                 reinterpret_cast<void *>(jni::setCutoff)},
+                {"setResonance", "(JF)V",                                                 reinterpret_cast<void *>(jni::setResonance)},
+        };
+
+        jniRegisterNativeMethods(
+                env,
+                "com/flatmapdev/synth/jni/NativeSynthFilter",
+                methods.data(),
+                methods.size()
+        );
+
+        return JNI_VERSION_1_6;
+    }
+
+    auto getFilter(
             JNIEnv *env,
             jobject  /*obj*/,
             jlong synthPtr
@@ -21,8 +48,7 @@ namespace jni {
         );
     }
 
-    JNIEXPORT auto JNICALL
-    Java_com_flatmapdev_synth_jni_NativeSynthFilter_setIsActive(
+    auto setIsActive(
             JNIEnv * /*env*/,
             jobject  /*obj*/,
             jlong synthPtr,
@@ -32,9 +58,7 @@ namespace jni {
         synth->getFilter().setIsActive(static_cast<bool>(isActive));
     }
 
-
-    JNIEXPORT auto JNICALL
-    Java_com_flatmapdev_synth_jni_NativeSynthFilter_setCutoff(
+    auto setCutoff(
             JNIEnv * /*env*/,
             jobject  /*obj*/,
             jlong synthPtr,
@@ -44,8 +68,7 @@ namespace jni {
         synth->getFilter().setCutoff(cutoffFrequency);
     }
 
-    JNIEXPORT auto JNICALL
-    Java_com_flatmapdev_synth_jni_NativeSynthFilter_setResonance(
+    auto setResonance(
             JNIEnv * /*env*/,
             jobject  /*obj*/,
             jlong synthPtr,
@@ -53,6 +76,5 @@ namespace jni {
     ) -> void {
         auto synth = &model::Synth::fromPtr(synthPtr);
         synth->getFilter().setResonance(resonance);
-    }
     }
 }  // namespace jni

--- a/app/src/main/cpp/jni/FilterJni.h
+++ b/app/src/main/cpp/jni/FilterJni.h
@@ -1,0 +1,10 @@
+#ifndef SYNTH_FILTERJNI_H
+#define SYNTH_FILTERJNI_H
+
+#include <jni.h>
+
+namespace jni {
+    jint registerFilterMethods(JNIEnv *env);
+} // namespace jni
+
+#endif //SYNTH_FILTERJNI_H

--- a/app/src/main/cpp/jni/OnLoad.cpp
+++ b/app/src/main/cpp/jni/OnLoad.cpp
@@ -1,0 +1,17 @@
+#include "OscillatorJni.h"
+#include "SynthEngineJni.h"
+#include <jni.h>
+
+namespace jni {
+    extern "C" auto JNI_OnLoad(JavaVM *vm, void */*reserved*/) -> jint {
+        JNIEnv *env;
+        if (vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
+            return JNI_ERR;
+        }
+
+        if (jni::registerSynthEngineMethods(env) == JNI_ERR) { return JNI_ERR; }
+        if (jni::registerOscillatorMethods(env) == JNI_ERR) { return JNI_ERR; }
+
+        return JNI_VERSION_1_6;
+    }
+}  // namespace jni

--- a/app/src/main/cpp/jni/OnLoad.cpp
+++ b/app/src/main/cpp/jni/OnLoad.cpp
@@ -1,4 +1,5 @@
 #include "OscillatorJni.h"
+#include "AmpEnvelopeJni.h"
 #include "FilterJni.h"
 #include "SynthEngineJni.h"
 #include <jni.h>
@@ -10,9 +11,10 @@ namespace jni {
             return JNI_ERR;
         }
 
-        if (jni::registerSynthEngineMethods(env) == JNI_ERR) { return JNI_ERR; }
-        if (jni::registerOscillatorMethods(env) == JNI_ERR) { return JNI_ERR; }
+        if (jni::registerAmpEnvelopeMethods(env) == JNI_ERR) { return JNI_ERR; }
         if (jni::registerFilterMethods(env) == JNI_ERR) { return JNI_ERR; }
+        if (jni::registerOscillatorMethods(env) == JNI_ERR) { return JNI_ERR; }
+        if (jni::registerSynthEngineMethods(env) == JNI_ERR) { return JNI_ERR; }
 
         return JNI_VERSION_1_6;
     }

--- a/app/src/main/cpp/jni/OnLoad.cpp
+++ b/app/src/main/cpp/jni/OnLoad.cpp
@@ -1,4 +1,5 @@
 #include "OscillatorJni.h"
+#include "FilterJni.h"
 #include "SynthEngineJni.h"
 #include <jni.h>
 
@@ -11,6 +12,7 @@ namespace jni {
 
         if (jni::registerSynthEngineMethods(env) == JNI_ERR) { return JNI_ERR; }
         if (jni::registerOscillatorMethods(env) == JNI_ERR) { return JNI_ERR; }
+        if (jni::registerFilterMethods(env) == JNI_ERR) { return JNI_ERR; }
 
         return JNI_VERSION_1_6;
     }

--- a/app/src/main/cpp/jni/OscillatorJni.cpp
+++ b/app/src/main/cpp/jni/OscillatorJni.cpp
@@ -1,7 +1,39 @@
+#include "OscillatorJni.h"
 #include "model/Synth.h"
 #include "model/WaveformType.h"
+#include <nativehelper/JNIHelp.h>
 
 namespace jni {
+    auto getOscillator(JNIEnv *env, jobject obj, jlong synth) -> jobject;
+
+    auto setOscillator(JNIEnv *env, jobject obj, jlong synth, jobject jOscillator) -> void;
+
+    auto setWaveform(JNIEnv *env, jobject obj, jlong synth, jint waveformTypeInt) -> void;
+
+    auto setPitchOffset(JNIEnv *env, jobject obj, jlong synth, jint pitchOffset) -> void;
+
+    auto registerOscillatorMethods(JNIEnv *env) -> jint {
+        jclass c = env->FindClass("com/flatmapdev/synth/jni/NativeSynthOscillator");
+        if (c == nullptr) { return JNI_ERR; }
+
+        std::vector<JNINativeMethod> methods{
+                {"getOscillator",  "(J)Lcom/flatmapdev/synth/oscillatorData/model/OscillatorData;", reinterpret_cast<void *>(jni::getOscillator)},
+                {"setOscillator",  "(JLcom/flatmapdev/synth/oscillatorData/model/OscillatorData;)V",                                                          reinterpret_cast<void *>(jni::setOscillator)},
+                {"setWaveform",    "(JI)V",                                                         reinterpret_cast<void *>(jni::setWaveform)},
+                {"setPitchOffset", "(JI)V",                                                         reinterpret_cast<void *>(jni::setPitchOffset)},
+        };
+
+        jniRegisterNativeMethods(
+                env,
+                "com/flatmapdev/synth/jni/NativeSynthOscillator",
+                methods.data(),
+                methods.size()
+
+        );
+
+        return JNI_VERSION_1_6;
+    }
+
     auto getOscillatorFromId(
             JNIEnv *env,
             jobject nativeSynthOscillator,
@@ -27,10 +59,7 @@ namespace jni {
         return *osc;
     }
 
-    extern "C" {
-
-    JNIEXPORT auto JNICALL
-    Java_com_flatmapdev_synth_jni_NativeSynthOscillator_getOscillator(
+    auto getOscillator(
             JNIEnv *env,
             jobject obj,
             jlong synth
@@ -46,8 +75,7 @@ namespace jni {
         );
     }
 
-    JNIEXPORT auto JNICALL
-    Java_com_flatmapdev_synth_jni_NativeSynthOscillator_setOscillator(
+    auto setOscillator(
             JNIEnv *env,
             jobject obj,
             jlong synth,
@@ -60,8 +88,7 @@ namespace jni {
         osc.setPitchOffset(pitchOffset);
     }
 
-    JNIEXPORT auto JNICALL
-    Java_com_flatmapdev_synth_jni_NativeSynthOscillator_setWaveform(
+    auto setWaveform(
             JNIEnv *env,
             jobject obj,
             jlong synth,
@@ -73,8 +100,7 @@ namespace jni {
         osc.setWaveform(std::move(waveform));
     }
 
-    JNIEXPORT auto JNICALL
-    Java_com_flatmapdev_synth_jni_NativeSynthOscillator_setPitchOffset(
+    auto setPitchOffset(
             JNIEnv *env,
             jobject obj,
             jlong synth,
@@ -84,6 +110,5 @@ namespace jni {
         osc.setPitchOffset(pitchOffset);
     }
 
-    }
 }  // namespace jni
 

--- a/app/src/main/cpp/jni/OscillatorJni.h
+++ b/app/src/main/cpp/jni/OscillatorJni.h
@@ -1,0 +1,9 @@
+#ifndef SYNTH_OSCILLATORJNI_H
+#define SYNTH_OSCILLATORJNI_H
+
+#include <jni.h>
+
+namespace jni {
+    jint registerOscillatorMethods(JNIEnv *env);
+} // namespace jni
+#endif //SYNTH_OSCILLATORJNI_H

--- a/app/src/main/cpp/jni/SynthEngineJni.cpp
+++ b/app/src/main/cpp/jni/SynthEngineJni.cpp
@@ -10,13 +10,23 @@
 #include <nativehelper/JNIHelp.h>
 
 namespace jni {
-    extern "C" {
-    auto JNI_OnLoad(JavaVM *vm, void */*reserved*/) -> jint {
-        JNIEnv *env;
-        if (vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
-            return JNI_ERR;
-        }
+    auto initialize(JNIEnv */* env */) -> jlong;
 
+    void cleanUp(JNIEnv * /*unused*/, jobject /* cls */, jlong synth);
+
+    auto getVersion(JNIEnv *env) -> jstring;
+
+    void start(JNIEnv */* env */, jclass /* cls */, jlong synthPtr);
+
+    void stop(JNIEnv */* env */, jclass /* cls */, jlong synthPtr);
+
+    void playNote(JNIEnv */* env */, jclass /* cls */, jlong synthPtr,
+                  jint pitch
+    );
+
+    void stopNote(JNIEnv */* env */, jclass /* cls */, jlong synthPtr);
+
+    auto registerSynthEngineMethods(JNIEnv *env) -> jint {
         jclass c = env->FindClass("com/flatmapdev/synth/jni/NativeSynthEngine");
         if (c == nullptr) { return JNI_ERR; }
 
@@ -38,7 +48,6 @@ namespace jni {
                                  methods.size());
 
         return JNI_VERSION_1_6;
-    }
     }
 
     auto initialize(
@@ -79,7 +88,7 @@ namespace jni {
     }
 
     void cleanUp(
-            JNIEnv */* env */,
+            JNIEnv * /*unused*/,
             jobject /* cls */,
             jlong synth
     ) {

--- a/app/src/main/cpp/jni/SynthEngineJni.cpp
+++ b/app/src/main/cpp/jni/SynthEngineJni.cpp
@@ -1,18 +1,40 @@
+#include "SynthEngineJni.h"
+
 #include "../synth/NoiseWaveform.h"
 #include "../synth/SineWaveform.h"
 #include "../synth/SquareWaveform.h"
 #include "../synth/TriangleWaveform.h"
 #include "model/Synth.h"
 #include "model/WaveformType.h"
-#include <jni.h>
+#include <nativehelper/JNIHelp.h>
 
 namespace jni {
-
-
     extern "C" {
 
-    JNIEXPORT auto JNICALL
-    Java_com_flatmapdev_synth_jni_NativeSynthEngine_initialize(
+    JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void */*reserved*/) {
+        JNIEnv *env;
+        if (vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
+            return JNI_ERR;
+        }
+
+        // Find your class. JNI_OnLoad is called from the correct class loader context for this to work.
+        jclass c = env->FindClass("com/flatmapdev/synth/jni/NativeSynthEngine");
+        if (c == nullptr) return JNI_ERR;
+
+        jniThrowNullPointerException(env, "Class not found");
+
+        JNINativeMethod methods[] = {
+                {"initialise", "([I)[I", (void *) jni::initialise}
+        };
+        jniRegisterNativeMethods(env,
+                                 "com/flatmapdev/synth/jni/NativeSynthEngine", methods,
+                                 NELEM(methods));
+
+        return JNI_VERSION_1_6;
+    }
+    }
+
+    auto initialise(
             JNIEnv */* env */
     ) -> jlong {
         auto waveform1 = jni::model::createWaveform(model::WaveformType::Sine);
@@ -49,6 +71,7 @@ namespace jni {
         ));
     }
 
+    extern "C" {
     JNIEXPORT void JNICALL
     Java_com_flatmapdev_synth_jni_NativeSynthEngine_cleanUp(
             JNIEnv */* env */,

--- a/app/src/main/cpp/jni/SynthEngineJni.h
+++ b/app/src/main/cpp/jni/SynthEngineJni.h
@@ -5,7 +5,21 @@
 #include <jni.h>
 
 namespace jni {
-    static jlong initialise(JNIEnv */* env */);
+    jlong initialize(JNIEnv */* env */);
+
+    void cleanUp(JNIEnv */* env */, jobject /* cls */, jlong synth);
+
+    auto getVersion(JNIEnv *env) -> jstring;
+
+    void start(JNIEnv */* env */, jclass /* cls */, jlong synthPtr);
+
+    void stop(JNIEnv */* env */, jclass /* cls */, jlong synthPtr);
+
+    void playNote(JNIEnv */* env */, jclass /* cls */, jlong synthPtr,
+                  jint pitch
+    );
+
+    void stopNote(JNIEnv */* env */, jclass /* cls */, jlong synthPtr);
 
 } // namespace jni
 #endif // JNI_SYNTHENGINEJNI_H

--- a/app/src/main/cpp/jni/SynthEngineJni.h
+++ b/app/src/main/cpp/jni/SynthEngineJni.h
@@ -5,21 +5,6 @@
 #include <jni.h>
 
 namespace jni {
-    jlong initialize(JNIEnv */* env */);
-
-    void cleanUp(JNIEnv */* env */, jobject /* cls */, jlong synth);
-
-    auto getVersion(JNIEnv *env) -> jstring;
-
-    void start(JNIEnv */* env */, jclass /* cls */, jlong synthPtr);
-
-    void stop(JNIEnv */* env */, jclass /* cls */, jlong synthPtr);
-
-    void playNote(JNIEnv */* env */, jclass /* cls */, jlong synthPtr,
-                  jint pitch
-    );
-
-    void stopNote(JNIEnv */* env */, jclass /* cls */, jlong synthPtr);
-
+    jint registerSynthEngineMethods(JNIEnv *env);
 } // namespace jni
 #endif // JNI_SYNTHENGINEJNI_H

--- a/app/src/main/cpp/jni/SynthEngineJni.h
+++ b/app/src/main/cpp/jni/SynthEngineJni.h
@@ -1,0 +1,11 @@
+
+#ifndef JNI_SYNTHENGINEJNI_H
+#define JNI_SYNTHENGINEJNI_H
+
+#include <jni.h>
+
+namespace jni {
+    static jlong initialise(JNIEnv */* env */);
+
+} // namespace jni
+#endif // JNI_SYNTHENGINEJNI_H


### PR DESCRIPTION
# Description
Use `RegisterNatives` to register JNI methods at runtime [as recommended by Google ](https://developer.android.com/training/articles/perf-jni#native-libraries)
> The advantages of RegisterNatives are that you get up-front checking that the symbols exist, plus you can have smaller and faster shared libraries by not exporting anything but JNI_OnLoad.

# Changes
- [x] Register JNI methods using `RegisterNatives`
- [x] Add Google's `libnativehelper` library which makes the above easier.
- [x] Add a test for the above which just initializes the native library on a device