### PR TITLE
Improve JNI code

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -2,6 +2,7 @@ include(cmake/list_transform.cmake)
 set(SYNTH_ENGINE_SOURCES
         jni/AmpEnvelopeJni.cpp
         jni/FilterJni.cpp
+        jni/Helpers.cpp
         jni/OnLoad.cpp
         jni/OscillatorJni.cpp
         jni/SynthEngineJni.cpp

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -41,7 +41,6 @@ android-*,\
 -fuchsia-*,\
 -cppcoreguidelines-pro-bounds-array-to-pointer-decay,\
 -cppcoreguidelines-pro-bounds-pointer-arithmetic,\
--cppcoreguidelines-pro-type-reinterpret-cast,\
 -cppcoreguidelines-pro-type-vararg,\
 -hicpp-no-array-decay,\
 -hicpp-vararg,\

--- a/app/src/main/cpp/jni/AmpEnvelopeJni.cpp
+++ b/app/src/main/cpp/jni/AmpEnvelopeJni.cpp
@@ -12,8 +12,8 @@ namespace jni {
         if (c == nullptr) { return JNI_ERR; }
 
         std::vector<JNINativeMethod> methods{
-                {"getAmpEnvelope", "(J)[F",  reinterpret_cast<void *>(jni::getAmpEnvelope)},
-                {"setAmpEnvelope", "(J[F)V", reinterpret_cast<void *>(jni::setAmpEnvelope)}
+                {"getAmpEnvelope", "(J)[F",  reinterpret_cast<void *>(jni::getAmpEnvelope)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"setAmpEnvelope", "(J[F)V", reinterpret_cast<void *>(jni::setAmpEnvelope)} // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         };
 
         jniRegisterNativeMethods(

--- a/app/src/main/cpp/jni/FilterJni.cpp
+++ b/app/src/main/cpp/jni/FilterJni.cpp
@@ -17,10 +17,10 @@ namespace jni {
         if (c == nullptr) { return JNI_ERR; }
 
         std::vector<JNINativeMethod> methods{
-                {"getFilter",    "(J)Lcom/flatmapdev/synth/filterData/model/FilterData;", reinterpret_cast<void *>(jni::getFilter)},
-                {"setIsActive",  "(JZ)V",                                                 reinterpret_cast<void *>(jni::setIsActive)},
-                {"setCutoff",    "(JF)V",                                                 reinterpret_cast<void *>(jni::setCutoff)},
-                {"setResonance", "(JF)V",                                                 reinterpret_cast<void *>(jni::setResonance)},
+                {"getFilter",    "(J)Lcom/flatmapdev/synth/filterData/model/FilterData;", reinterpret_cast<void *>(jni::getFilter)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"setIsActive",  "(JZ)V",                                                 reinterpret_cast<void *>(jni::setIsActive)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"setCutoff",    "(JF)V",                                                 reinterpret_cast<void *>(jni::setCutoff)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"setResonance", "(JF)V",                                                 reinterpret_cast<void *>(jni::setResonance)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         };
 
         jniRegisterNativeMethods(

--- a/app/src/main/cpp/jni/FilterJni.h
+++ b/app/src/main/cpp/jni/FilterJni.h
@@ -4,7 +4,7 @@
 #include <jni.h>
 
 namespace jni {
-    jint registerFilterMethods(JNIEnv *env);
+    jint setUpFilterJni(JNIEnv *env);
 } // namespace jni
 
 #endif //SYNTH_FILTERJNI_H

--- a/app/src/main/cpp/jni/Helpers.cpp
+++ b/app/src/main/cpp/jni/Helpers.cpp
@@ -1,0 +1,32 @@
+#include "Helpers.h"
+#include <android/log.h>
+#include <jni.h>
+#include <nativehelper/JNIHelp.h>
+
+auto jni::findClass(JNIEnv *env, const char *name) -> jclass {
+    auto cls = env->FindClass(name);
+    if (cls == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, LOG_TAG,
+                            "Cannot find class %s", name);
+    }
+    return cls;
+}
+
+auto jni::getFieldID(JNIEnv *env, jclass clazz, const char *name, const char *sig) -> jfieldID {
+    auto fieldId = env->GetFieldID(clazz, name, sig);
+    if (fieldId == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, LOG_TAG,
+                            "Cannot find field named %s with signature %s", name, sig);
+    }
+    return fieldId;
+}
+
+auto jni::getMethodID(JNIEnv *env, jclass clazz, const char *name, const char *sig) -> jmethodID {
+    auto methodId = env->GetMethodID(clazz, name, sig);
+    if (methodId == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, LOG_TAG,
+                            "Cannot find method named %s with signature %s", name, sig);
+    }
+    return methodId;
+}
+

--- a/app/src/main/cpp/jni/Helpers.h
+++ b/app/src/main/cpp/jni/Helpers.h
@@ -1,0 +1,16 @@
+#ifndef JNI_HELPERS_H
+#define JNI_HELPERS_H
+
+#include <jni.h>
+
+namespace jni {
+    constexpr auto LOG_TAG = "CppJni";
+
+    jclass findClass(JNIEnv *env, const char *name);
+
+    jfieldID getFieldID(JNIEnv *env, jclass clazz, const char *name, const char *sig);
+
+    jmethodID getMethodID(JNIEnv *env, jclass clazz, const char *name, const char *sig);
+}
+
+#endif //JNI_HELPERS_H

--- a/app/src/main/cpp/jni/OnLoad.cpp
+++ b/app/src/main/cpp/jni/OnLoad.cpp
@@ -6,10 +6,11 @@
 
 namespace jni {
     extern "C" auto JNI_OnLoad(JavaVM *vm, void */*reserved*/) -> jint {
-        JNIEnv *env;
-        if (vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
+        void *envVoidPtr;
+        if (vm->GetEnv(&envVoidPtr, JNI_VERSION_1_6) != JNI_OK) {
             return JNI_ERR;
         }
+        auto *env = static_cast<JNIEnv *>(envVoidPtr);
 
         if (jni::registerAmpEnvelopeMethods(env) == JNI_ERR) { return JNI_ERR; }
         if (jni::registerFilterMethods(env) == JNI_ERR) { return JNI_ERR; }

--- a/app/src/main/cpp/jni/OnLoad.cpp
+++ b/app/src/main/cpp/jni/OnLoad.cpp
@@ -13,8 +13,8 @@ namespace jni {
         auto *env = static_cast<JNIEnv *>(envVoidPtr);
 
         if (jni::registerAmpEnvelopeMethods(env) == JNI_ERR) { return JNI_ERR; }
-        if (jni::registerFilterMethods(env) == JNI_ERR) { return JNI_ERR; }
-        if (jni::registerOscillatorMethods(env) == JNI_ERR) { return JNI_ERR; }
+        if (jni::setUpFilterJni(env) == JNI_ERR) { return JNI_ERR; }
+        if (jni::setUpOscillatorJni(env) == JNI_ERR) { return JNI_ERR; }
         if (jni::registerSynthEngineMethods(env) == JNI_ERR) { return JNI_ERR; }
 
         return JNI_VERSION_1_6;

--- a/app/src/main/cpp/jni/OscillatorJni.cpp
+++ b/app/src/main/cpp/jni/OscillatorJni.cpp
@@ -1,20 +1,32 @@
 #include "OscillatorJni.h"
+#include "Helpers.h"
 #include "model/Synth.h"
 #include "model/WaveformType.h"
 #include <nativehelper/JNIHelp.h>
 
 namespace jni {
+    struct NativeOscillatorClassData {
+        jfieldID oscillatorId;
+    } classData;
+
+    struct OscillatorDataClassData {
+        jclass cls;
+        jmethodID constructor;
+        jfieldID pitchOffset;
+        jfieldID waveformType;
+    } oscillatorDataClassData;
+
     auto getOscillator(JNIEnv *env, jobject obj, jlong synth) -> jobject;
 
-    auto setOscillator(JNIEnv *env, jobject obj, jlong synth, jobject jOscillator) -> void;
+    auto setOscillator(JNIEnv *env, jobject obj, jlong synth, jobject jOscillatorData) -> void;
 
     auto setWaveform(JNIEnv *env, jobject obj, jlong synth, jint waveformTypeInt) -> void;
 
     auto setPitchOffset(JNIEnv *env, jobject obj, jlong synth, jint pitchOffset) -> void;
 
-    auto registerOscillatorMethods(JNIEnv *env) -> jint {
-        jclass c = env->FindClass("com/flatmapdev/synth/jni/NativeSynthOscillator");
-        if (c == nullptr) { return JNI_ERR; }
+    auto setUpOscillatorJni(JNIEnv *env) -> jint {
+        jclass cls = findClass(env, "com/flatmapdev/synth/jni/NativeSynthOscillator");
+        if (cls == nullptr) { return JNI_ERR; }
 
         std::vector<JNINativeMethod> methods{
                 {"getOscillator",  "(J)Lcom/flatmapdev/synth/oscillatorData/model/OscillatorData;",  reinterpret_cast<void *>(jni::getOscillator)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -22,7 +34,6 @@ namespace jni {
                 {"setWaveform",    "(JI)V",                                                          reinterpret_cast<void *>(jni::setWaveform)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
                 {"setPitchOffset", "(JI)V",                                                          reinterpret_cast<void *>(jni::setPitchOffset)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         };
-
         jniRegisterNativeMethods(
                 env,
                 "com/flatmapdev/synth/jni/NativeSynthOscillator",
@@ -30,6 +41,27 @@ namespace jni {
                 methods.size()
 
         );
+
+        classData.oscillatorId = getFieldID(env, cls, "oscillatorId", "I");
+        if (classData.oscillatorId == nullptr) { return JNI_ERR; }
+
+        oscillatorDataClassData.cls = reinterpret_cast<jclass>( // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                env->NewGlobalRef(findClass(env,
+                                            "com/flatmapdev/synth/oscillatorData/model/OscillatorData"
+                ))
+        );
+        if (oscillatorDataClassData.cls == nullptr) { return JNI_ERR; }
+        oscillatorDataClassData.constructor = getMethodID(env, oscillatorDataClassData.cls,
+                                                          "<init>", "(II)V");
+        if (oscillatorDataClassData.constructor == nullptr) { return JNI_ERR; }
+        oscillatorDataClassData.pitchOffset = getFieldID(env, oscillatorDataClassData.cls,
+                                                         "pitchOffset",
+                                                         "I");
+        if (oscillatorDataClassData.pitchOffset == nullptr) { return JNI_ERR; }
+        oscillatorDataClassData.waveformType = getFieldID(env, oscillatorDataClassData.cls,
+                                                          "waveformType",
+                                                          "I");
+        if (oscillatorDataClassData.waveformType == nullptr) { return JNI_ERR; }
 
         return JNI_VERSION_1_6;
     }
@@ -40,9 +72,7 @@ namespace jni {
             jlong synthPtr
     ) -> synth::Oscillator & {
         auto synth = &model::Synth::fromPtr(synthPtr);
-        jclass cls = env->GetObjectClass(nativeSynthOscillator);
-        jfieldID field = env->GetFieldID(cls, "oscillatorId", "I");
-        int oscillatorId = env->GetIntField(nativeSynthOscillator, field);
+        int oscillatorId = env->GetIntField(nativeSynthOscillator, classData.oscillatorId);
 
         synth::Oscillator *osc;
         switch (oscillatorId) {
@@ -65,11 +95,8 @@ namespace jni {
             jlong synth
     ) -> jobject {
         synth::Oscillator &osc = getOscillatorFromId(env, obj, synth);
-        jclass oscillatorClass = env->FindClass(
-                "com/flatmapdev/synth/oscillatorData/model/OscillatorData");
-        jmethodID oscillatorConstructor = env->GetMethodID(oscillatorClass, "<init>", "(II)V");
         auto waveformType = static_cast<model::WaveformType>(osc.getWaveform().getLabel());
-        return env->NewObject(oscillatorClass, oscillatorConstructor,
+        return env->NewObject(oscillatorDataClassData.cls, oscillatorDataClassData.constructor,
                               osc.getPitchOffset(),
                               static_cast<jint>(waveformType)
         );
@@ -79,13 +106,15 @@ namespace jni {
             JNIEnv *env,
             jobject obj,
             jlong synth,
-            jobject jOscillator
+            jobject jOscillatorData
     ) -> void {
         synth::Oscillator &osc = getOscillatorFromId(env, obj, synth);
-        jclass cls = env->GetObjectClass(jOscillator);
-        jfieldID fid = env->GetFieldID(cls, "pitchOffset", "I");
-        jint pitchOffset = env->GetIntField(jOscillator, fid);
-        osc.setPitchOffset(pitchOffset);
+
+        jint pitchOffset = env->GetIntField(jOscillatorData, oscillatorDataClassData.pitchOffset);
+        setPitchOffset(env, obj, synth, pitchOffset);
+
+        jint waveformType = env->GetIntField(jOscillatorData, oscillatorDataClassData.waveformType);
+        setWaveform(env, obj, synth, waveformType);
     }
 
     auto setWaveform(

--- a/app/src/main/cpp/jni/OscillatorJni.cpp
+++ b/app/src/main/cpp/jni/OscillatorJni.cpp
@@ -17,10 +17,10 @@ namespace jni {
         if (c == nullptr) { return JNI_ERR; }
 
         std::vector<JNINativeMethod> methods{
-                {"getOscillator",  "(J)Lcom/flatmapdev/synth/oscillatorData/model/OscillatorData;", reinterpret_cast<void *>(jni::getOscillator)},
-                {"setOscillator",  "(JLcom/flatmapdev/synth/oscillatorData/model/OscillatorData;)V",                                                          reinterpret_cast<void *>(jni::setOscillator)},
-                {"setWaveform",    "(JI)V",                                                         reinterpret_cast<void *>(jni::setWaveform)},
-                {"setPitchOffset", "(JI)V",                                                         reinterpret_cast<void *>(jni::setPitchOffset)},
+                {"getOscillator",  "(J)Lcom/flatmapdev/synth/oscillatorData/model/OscillatorData;",  reinterpret_cast<void *>(jni::getOscillator)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"setOscillator",  "(JLcom/flatmapdev/synth/oscillatorData/model/OscillatorData;)V", reinterpret_cast<void *>(jni::setOscillator)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"setWaveform",    "(JI)V",                                                          reinterpret_cast<void *>(jni::setWaveform)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"setPitchOffset", "(JI)V",                                                          reinterpret_cast<void *>(jni::setPitchOffset)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         };
 
         jniRegisterNativeMethods(

--- a/app/src/main/cpp/jni/OscillatorJni.h
+++ b/app/src/main/cpp/jni/OscillatorJni.h
@@ -4,6 +4,6 @@
 #include <jni.h>
 
 namespace jni {
-    jint registerOscillatorMethods(JNIEnv *env);
+    jint setUpOscillatorJni(JNIEnv *env);
 } // namespace jni
 #endif //SYNTH_OSCILLATORJNI_H

--- a/app/src/main/cpp/jni/SynthEngineJni.cpp
+++ b/app/src/main/cpp/jni/SynthEngineJni.cpp
@@ -30,16 +30,14 @@ namespace jni {
         jclass c = env->FindClass("com/flatmapdev/synth/jni/NativeSynthEngine");
         if (c == nullptr) { return JNI_ERR; }
 
-        auto methods = std::vector<JNINativeMethod>{
-                {
-                        {"initialize", "()J", reinterpret_cast<void *>(jni::initialize)},
-                        {"cleanUp", "(J)V", reinterpret_cast<void *>(jni::cleanUp)},
-                        {"getVersion", "()Ljava/lang/String;", reinterpret_cast<void *>(jni::getVersion)},
-                        {"start", "(J)V", reinterpret_cast<void *>(jni::start)},
-                        {"stop", "(J)V", reinterpret_cast<void *>(jni::stop)},
-                        {"playNote", "(JI)V", reinterpret_cast<void *>(jni::playNote)},
-                        {"stopNote", "(J)V", reinterpret_cast<void *>(jni::stopNote)},
-                }
+        std::vector<JNINativeMethod> methods{
+                {"initialize", "()J",                  reinterpret_cast<void *>(jni::initialize)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"cleanUp",    "(J)V",                 reinterpret_cast<void *>(jni::cleanUp)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"getVersion", "()Ljava/lang/String;", reinterpret_cast<void *>(jni::getVersion)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"start",      "(J)V",                 reinterpret_cast<void *>(jni::start)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"stop",       "(J)V",                 reinterpret_cast<void *>(jni::stop)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"playNote",   "(JI)V",                reinterpret_cast<void *>(jni::playNote)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                {"stopNote",   "(J)V",                 reinterpret_cast<void *>(jni::stopNote)}, // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         };
 
         jniRegisterNativeMethods(env,


### PR DESCRIPTION
Improve JNI code:
- [x] Re-enable the `reinterpret_cast` lint by annotating accepted usages in the code
- [x] Cache Java class, method and field info in the JNI code